### PR TITLE
Updated superagent version, sample variable error

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "msgraph-sdk-javascript",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Microsoft Graph JavaScript SDK",
   "main": "lib/src/index.js",
   "typings": "lib/src/index",
@@ -20,7 +20,7 @@
     "test": "mocha lib/test"
   },
   "dependencies": {
-    "superagent": "^2.2.0"
+    "superagent": "~3.3.0"
   },
   "repository": {
     "type": "git",

--- a/samples/node/node-sample.js
+++ b/samples/node/node-sample.js
@@ -36,7 +36,7 @@ client
     .then((res) => {
         console.log(res);
     }).catch((err) => {
-        console.log(res);
+        console.log(err);
     });
 
 // Update the authenticated users birthday.


### PR DESCRIPTION
This should fix superagent throwing the following error:
```
Uncaught DOMException: Failed to read the 'responseText' property from 'XMLHttpRequest': The value is only accessible if the object's 'responseType' is '' or 'text' (was 'blob').
    at Request.eval (webpack:///./~/superagent/lib/client.js?:490:45)

```