### PR TITLE
Export Options and GraphRequest from index.ts

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -27,3 +27,6 @@ export class Client {
     }
 
 }
+
+export Options;
+export GraphRequest;


### PR DESCRIPTION
This will allow developers to import the Options and GraphRequest objects without a path based import statement.

Before:
import { Client } from '@ microsoft/microsoft-graph-client'
import { Options } from '@ microsoft/microsoft-graph-client/lib/src/common';
import { GraphRequest } from '@ microsoft/microsoft-graph-client/lib/src/GraphRequest';

After:
import { Client, Options, GraphRequest } from '@ microsoft/microsoft-graph-client'