### PR TITLE
Fix typing for select, expand, and orderby

### DIFF
--- a/spec/core/urlGeneration.ts
+++ b/spec/core/urlGeneration.ts
@@ -32,6 +32,12 @@ cases.push({
 });
 
 cases.push({
+    url: "https://graph.microsoft.com/v1.0/me?$select=displayName,jobTitle",
+    request: client.api("/me")
+                .select("displayName", "jobTitle")
+});
+
+cases.push({
     url: "https://graph.microsoft.com/beta/me?$select=displayName,jobTitle",
     request: client.api("/me")
             .version("beta")

--- a/src/GraphRequest.ts
+++ b/src/GraphRequest.ts
@@ -94,7 +94,7 @@ export class GraphRequest {
     }
 
     
-    private urlJoin(urlSegments:[string]):String {
+    private urlJoin(urlSegments:string[]):String {
         const tr = (s) => s.replace(/\/+$/, '');
         const tl = (s) => s.replace(/^\/+/, '');
         const joiner = (pre, cur) => [tr(pre), tl(cur)].join('/');
@@ -127,17 +127,23 @@ export class GraphRequest {
      *     and .select("displayName", "birthday")
      * 
      */
-    select(properties:string|[string]):GraphRequest {
+    select(properties: string[]):GraphRequest
+    select(properties: string, ...additionalProperties: string[]):GraphRequest
+    select(properties:string|string[]):GraphRequest {
         this.addCsvQueryParamater("$select", properties, arguments);
         return this;
     }
 
-    expand(properties:string|[string]):GraphRequest {
+    expand(properties: string[]):GraphRequest
+    expand(properties: string, ...additionalProperties: string[]):GraphRequest
+    expand(properties:string|string[]):GraphRequest {
         this.addCsvQueryParamater("$expand", properties, arguments);
         return this;
     }
 
-    orderby(properties:string|[string]):GraphRequest {
+    orderby(properties: string[]):GraphRequest
+    orderby(properties: string, ...additionalProperties: string[]):GraphRequest
+    orderby(properties:string|string[]):GraphRequest {
         this.addCsvQueryParamater("$orderby", properties, arguments);
         return this;
     }
@@ -174,7 +180,7 @@ export class GraphRequest {
     }
 
     // helper for $select, $expand and $orderby (must be comma separated)
-    private addCsvQueryParamater(propertyName:string, propertyValue:string|[string], additionalProperties:IArguments) {
+    private addCsvQueryParamater(propertyName:string, propertyValue:string|string[], additionalProperties:IArguments) {
         // if there are already $propertyName value there, append a ","
         this.urlComponents.oDataQueryParams[propertyName] = this.urlComponents.oDataQueryParams[propertyName] ? this.urlComponents.oDataQueryParams[propertyName] + "," : "";
 


### PR DESCRIPTION
I noticed that the typing for select defines a tuple type with a single item, and not an array type. This caused code such as

```
const userProps: string[] = [
  'city',
  'country'
]

c.api('/me').select(userProps).buildFullUrl()
```

to fail typechecking with the message

```
Argument of type 'string[]' is not assignable to parameter of type 'string | [string]'.
  Type 'string[]' is not assignable to type '[string]'.
    Property '0' is missing in type 'string[]'.
```

This also fixes typechecking for supplying multiple arguments, where `c.api('/me').select('city', 'country').buildFullUrl()` would get the message `Expected 1 arguments, but got 2.`
