### PR TITLE
Correct the parameter to accept array of type string

### DIFF
--- a/src/GraphRequest.ts
+++ b/src/GraphRequest.ts
@@ -94,7 +94,7 @@ export class GraphRequest {
     }
 
     
-    private urlJoin(urlSegments:[string]):String {
+    private urlJoin(urlSegments:string[]):String {
         const tr = (s) => s.replace(/\/+$/, '');
         const tl = (s) => s.replace(/^\/+/, '');
         const joiner = (pre, cur) => [tr(pre), tl(cur)].join('/');


### PR DESCRIPTION
When importing the typescript file directly to write a client rather than using compiled javascript files in the repository, it was giving compilation error