### PR TITLE
Check for object when extracting error

### DIFF
--- a/lib/src/ResponseHandler.js
+++ b/lib/src/ResponseHandler.js
@@ -17,7 +17,7 @@ var ResponseHandler = (function () {
     ResponseHandler.ParseError = function (rawErr) {
         var errObj;
         if (!('rawResponse' in rawErr)) {
-            if (rawErr.response !== undefined && rawErr.response.body !== null && 'error' in rawErr.response.body) {
+            if (rawErr.response !== undefined && rawErr.response.body !== null && typeof rawErr.response.body === 'object' && 'error' in rawErr.response.body) {
                 errObj = rawErr.response.body.error;
             }
         }


### PR DESCRIPTION
We've been using this library (npm version v1.0.0) in production and had a few occurrences of:

```
TypeError: Cannot use 'in' operator to search for 'error' in undefined
at Function.ResponseHandler.ParseError (ResponseHandler.js:20)
at Function.ResponseHandler.init (ResponseHandler.js:14)
at (/app/node_modules/@microsoft/microsoft-graph-client/lib/src/GraphRequest.js:191)
```

I've changed the check to ensure the `in` operator is only being used against an object.