### PR TITLE
Make MSALAuthenticationProvider.userAgentApplication public

### DIFF
--- a/src/MSALAuthenticationProvider.ts
+++ b/src/MSALAuthenticationProvider.ts
@@ -34,10 +34,10 @@ export class MSALAuthenticationProvider implements AuthenticationProvider {
 	private scopes: string[];
 
 	/**
-	 * @private
+	 * @public
 	 * A member holding an instance of UserAgentApplication returned from MSAL
 	 */
-	private userAgentApplication: UserAgentApplication;
+	public userAgentApplication: UserAgentApplication;
 
 	/**
 	 * @public

--- a/src/browser/MSALAuthenticationProvider.ts
+++ b/src/browser/MSALAuthenticationProvider.ts
@@ -38,10 +38,10 @@ export class MSALAuthenticationProvider implements AuthenticationProvider {
 	private scopes: string[];
 
 	/**
-	 * @private
+	 * @public
 	 * A member holding an instance of UserAgentApplication returned from MSAL
 	 */
-	private userAgentApplication: any;
+	public userAgentApplication: any;
 
 	/**
 	 * @public


### PR DESCRIPTION
## Summary

Changes access of the `userAgentApplication` member of the `MSALAuthenticationProvider` class to public

## Motivation

Allows the ability to inspect and change the login state, by allowing access to the getUser() and logout() methods on the userAgentApplication member.

## Test plan

Run this code snippet in a sample project to check if the client is logged in, and if so, log it out.

```
const authProvider = new MSALAuthenticationProvider(clientID, graphScopes, options);

const clientOptions: ClientOptions = {
  authProvider: authProvider
};

const client = Client.initWithMiddleware(this.clientOptions);

if (!!authProvider.userAgentApplication.getUser()) { // user logged in?
      authProvider.userAgentApplication.logout();  // log out
}
```

## Types of changes

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

-   [x] I have read the **CONTRIBUTING** document.
-   [x] My code follows the code style of this project.
-   [ ] My change requires a change to the documentation.
-   [ ] I have updated the documentation accordingly.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
