### PR TITLE
Fix in browser samples

### DIFF
--- a/samples/browser/src/request.js
+++ b/samples/browser/src/request.js
@@ -29,7 +29,7 @@ let request = {
 			() => {
 				client
 					.api("/me/photo/$value")
-					.responseType(MicrosoftGraph.ResponseType.BLOB)
+					.responseType("blob")
 					.put(file)
 					.then((res) => {
 						request


### PR DESCRIPTION
## Summary

Looks like the ```MicrosoftGraph.ResponseType.BLOB``` enum is not supported anymore in the last version (1.7.0), so I replaced it with ```"blob"```

## Motivation

Bring accurate and up to date samples.

## Test plan

## Closing issues

## Types of changes

-   [ x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

-   [ x] I have read the **CONTRIBUTING** document.
-   [ x] My code follows the code style of this project.
-   [ x] My change requires a change to the documentation.
-   [ ] I have updated the documentation accordingly.
-   [ ] I have added tests to cover my changes.
-   [ ] All new and existing tests passed.
