### PR TITLE
Updated additional resources links

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,8 +193,8 @@ Please see the [contributing guidelines](CONTRIBUTING.md).
 
 -   [Microsoft Graph website](https://graph.microsoft.io)
 -   [Microsoft Graph TypeScript types](https://github.com/microsoftgraph/msgraph-typescript-typings/)
--   [Angular.js sample using the JavaScript client library](https://github.com/microsoftgraph/angular-connect-sample)
--   [Node.js sample using the JavaScript client library](https://github.com/microsoftgraph/nodejs-connect-sample)
+-   [Build Angular single-page apps with Microsoft Graph](https://github.com/microsoftgraph/msgraph-training-angularspa)
+-   [Build Node.js Express apps with Microsoft Graph](https://github.com/microsoftgraph/msgraph-training-nodeexpressapp)
 -   [Office Dev Center](http://dev.office.com/)
 
 ## Third Party Notices


### PR DESCRIPTION


## Summary
The links pointed to projects that are archived and have been replaced by different ones. Updated the links to the new projects.

## Motivation

When I was looking into getting started with this sdk, I found out that some links were pointing to old archived projects which have been replaced. By changing the links the users won't be redirected to the old archived project but to the up to date one. 

## Test plan

See if links are properly updated by clicking.

## Types of changes

-   [x] Bugfix, link updates.