### PR TITLE
Fix syntax error in README code sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Refer devDependencies in [package.json](./package.json) for the compatible msal 
 // Configuration options for MSAL @see https://github.com/AzureAD/microsoft-authentication-library-for-js/wiki/MSAL.js-1.0.0-api-release#configuration-options
 const msalConfig = {
 	auth: {
-		clientId: "your_client_id"; // Client Id of the registered application
+		clientId: "your_client_id", // Client Id of the registered application
 		redirectUri: "your_redirect_uri",
 	},
 };


### PR DESCRIPTION
## Summary

There's a syntax error in the MSAL configuration code sample that prevents folks from running the code when copy & pasted into their solution.

I ran into it while onboarding to the library, specifically when trying to use `ImplicitMSALAuthenticationProvider`.

cc: @natalieethell

## Motivation

This is a minor documentation change.

## Test plan

N/A

## Closing issues

N/A

## Types of changes

-   [x] Documentation
-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

-   [x] I have read the **CONTRIBUTING** document.
-   [x] My code follows the code style of this project.
-   [x] My change requires a change to the documentation.
-   [x] I have updated the documentation accordingly.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
