### PR TITLE
Adds support for multiple cached authorities for MSAL auth provider

### DIFF
--- a/src/ImplicitMSALAuthenticationProvider.ts
+++ b/src/ImplicitMSALAuthenticationProvider.ts
@@ -70,6 +70,7 @@ export class ImplicitMSALAuthenticationProvider implements AuthenticationProvide
 		}
 		if (this.msalApplication.getAccount()) {
 			const tokenRequest: AuthenticationParameters = {
+				authority: this.msalApplication.authority,
 				scopes,
 			};
 			try {
@@ -90,6 +91,7 @@ export class ImplicitMSALAuthenticationProvider implements AuthenticationProvide
 		} else {
 			try {
 				const tokenRequest: AuthenticationParameters = {
+					authority: this.msalApplication.authority,
 					scopes,
 				};
 				await this.msalApplication.loginPopup(tokenRequest);


### PR DESCRIPTION
Adds support for multiple cached authorities for MSAL auth provider by explicitly passing the msalApplication.authority value in the tokenRequest.

If a user is logged in with multiple MSAL authorities on the same site, there are multiple tokens and authorities cached on the client.  Without explicitly passing the authority, the MSAL application is unable to determine which token to retrieve and fails with: Multiple authorities found in the cache. Pass authority in the API overload.

We encountered this scenario when requiring users to sign into a Sharepoint account, but also sign into a separate AAD/MSA account for MS Graph access.  This update fixes the issue.