### PR TITLE
Updated GraphRequest.ts for .count() scenario

### DIFF
--- a/src/GraphRequest.ts
+++ b/src/GraphRequest.ts
@@ -489,7 +489,7 @@ export class GraphRequest {
 	 * @param {boolean} isCount - The count boolean
 	 * @returns The same GraphRequest instance that is being called with
 	 */
-	public count(isCount: boolean): GraphRequest {
+	public count(isCount: boolean = false): GraphRequest {
 		this.urlComponents.oDataQueryParams.$count = isCount.toString();
 		return this;
 	}


### PR DESCRIPTION
Updated GraphRequest.ts to handle .count() when no parameter is specified

## Summary
When the query parameter .count() didn't have any parameter passed, it used to give an error.
So adding the default value as **false** for this case (this is according to the graph behavior).
<!-- Summary of the PR -->

## Closing issues
#241 
<!-- Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->

Fixes #241 

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [X] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

-   [ ] I have read the **CONTRIBUTING** document.
-   [X] My code follows the code style of this project.
-   [ ] My change requires a change to the documentation.
-   [ ] I have updated the documentation accordingly.
-   [ ] I have added tests to cover my changes.
-   [ ] All new and existing tests passed.
