### PR TITLE
Issue 291 - Changed parse path function considering nested query parameters.

### DIFF
--- a/spec/core/urlGeneration.ts
+++ b/spec/core/urlGeneration.ts
@@ -113,6 +113,37 @@ cases.push({
 		.query({ $select: "id" }),
 });
 
+// handling an invalid input
+cases.push({
+	url: "https://graph.microsoft.com/v1.0/me/people?$select=displayName,title&select=value&test",
+	request: client
+		.api("/me/people")
+		.version("v1.0")
+		.select(["displayName", "title"])
+		.query({ select: "value" })
+		.query("test"),
+});
+
+// handling an invalid input
+cases.push({
+	url: "https://graph.microsoft.com/v1.0/me/people?$expand=address($select=home,$expand=city)&$select=home,displayName,title&select=value&test",
+	request: client
+		.api("/me/people?$expand=address($select=home,$expand=city)&$select=home")
+		.version("v1.0")
+		.select(["displayName", "title"])
+		.query({ select: "value" })
+		.query("test"),
+});
+
+cases.push({
+	url: "https://graph.microsoft.com/v1.0/me/people?$expand=home($select=home)&name=test",
+	request: client.api("/me/people").query("?name=test&$expand=home($select=home)"),
+});
+cases.push({
+	url: "https://graph.microsoft.com/v1.0/me/people?$expand=home($select=home)&name=test",
+	request: client.api("/me/people?name=test&$expand=home($select=home)"),
+});
+
 cases.push({
 	url: "https://graph.microsoft.com/v1.0/me/drive/root?$expand=children($select=name),permissions",
 	request: client

--- a/spec/core/urlGeneration.ts
+++ b/spec/core/urlGeneration.ts
@@ -92,6 +92,28 @@ cases.push({
 });
 
 cases.push({
+	url: "https://graph.microsoft.com/beta/me/people?$select=displayName,title,id&$count=false&$expand=a($expand=a,b)",
+	request: client
+		.api("/me/people")
+		.version("beta")
+		.select(["displayName", "title"])
+		.count(true)
+		.expand("a($expand=a,b)")
+		.query("$select=id")
+		.query("$count=false"),
+});
+
+cases.push({
+	url: "https://graph.microsoft.com/v1.0/me/people?$select=displayName,title,id&select=value",
+	request: client
+		.api("/me/people")
+		.version("v1.0")
+		.select(["displayName", "title"])
+		.query({ select: "value" })
+		.query({ $select: "id" }),
+});
+
+cases.push({
 	url: "https://graph.microsoft.com/v1.0/me/drive/root?$expand=children($select=name),permissions",
 	request: client
 		.api("me/drive/root")

--- a/spec/core/urlParsing.ts
+++ b/spec/core/urlParsing.ts
@@ -34,6 +34,11 @@ const testCases = {
 	"me?$select=displayName&$select=id": "https://graph.microsoft.com/v1.0/me?$select=displayName,id",
 	"/me?$filter=b&$filter=a": "https://graph.microsoft.com/v1.0/me?$filter=a",
 	"https://graph.microsoft.com/v1.0/me?$top=4&$expand=4&$iscount=true&$top=2": "https://graph.microsoft.com/v1.0/me?$top=2&$expand=4&$iscount=true",
+	"/items?$expand=fields($select=Title)&$expand=name($select=firstName)": "https://graph.microsoft.com/v1.0/items?$expand=fields($select=Title),name($select=firstName)",
+
+	// Passing invalid parameters
+	"/me?&test&123": "https://graph.microsoft.com/v1.0/me?&test&123",
+	"/me?$select($select=name)": "https://graph.microsoft.com/v1.0/me?$select($select=name)",
 };
 
 describe("urlParsing.ts", () => {

--- a/spec/core/urlParsing.ts
+++ b/spec/core/urlParsing.ts
@@ -28,6 +28,12 @@ const testCases = {
 	"me?$select=displayName": "https://graph.microsoft.com/v1.0/me?$select=displayName",
 	"me?select=displayName": "https://graph.microsoft.com/v1.0/me?select=displayName",
 	"https://graph.microsoft.com/beta/me?select=displayName": "https://graph.microsoft.com/beta/me?select=displayName",
+
+	// test for nested query parameters
+	"https://graph.microsoft.com/beta/identityGovernance/entitlementManagement/accessPackages/?$expand=accessPackageAssignmentPolicies,accessPackageResourceRoleScopes($expand=accessPackageResourceRole,accessPackageResourceScope)": "https://graph.microsoft.com/beta/identityGovernance/entitlementManagement/accessPackages/?$expand=accessPackageAssignmentPolicies,accessPackageResourceRoleScopes($expand=accessPackageResourceRole,accessPackageResourceScope)",
+	"me?$select=displayName&$select=id": "https://graph.microsoft.com/v1.0/me?$select=displayName,id",
+	"/me?$filter=b&$filter=a": "https://graph.microsoft.com/v1.0/me?$filter=a",
+	"https://graph.microsoft.com/v1.0/me?$top=4&$expand=4&$iscount=true&$top=2": "https://graph.microsoft.com/v1.0/me?$top=2&$expand=4&$iscount=true",
 };
 
 describe("urlParsing.ts", () => {
@@ -42,5 +48,5 @@ describe("urlParsing.ts", () => {
 			}
 		}
 	});
-	/* tslint:enable: no-string-literal */
 });
+/* tslint:enable: no-string-literal */

--- a/src/GraphRequest.ts
+++ b/src/GraphRequest.ts
@@ -308,6 +308,7 @@ export class GraphRequest {
 	 * Sets values into the urlComponents property of GraphRequest object.
 	 * @param {string} paramKey - the query parameter key
 	 * @param {string} paramValue - the query paramter value
+	 * @returns nothing
 	 */
 	private setURLComponentsQueryParamater(paramKey: string, paramValue: string | number): void {
 		if (oDataQueryNames.indexOf(paramKey) !== -1) {
@@ -483,7 +484,7 @@ export class GraphRequest {
 	 * @public
 	 * To add properties for select OData Query param
 	 * @param {string|string[]} properties - The Properties value
-	 * @returns The same GraphRequest instance that is being called with
+	 * @returns The same GraphRequest instance that is being called with, after adding the properties for $select query
 	 */
 	/*
 	 * Accepts .select("displayName,birthday")
@@ -500,7 +501,7 @@ export class GraphRequest {
 	 * @public
 	 * To add properties for expand OData Query param
 	 * @param {string|string[]} properties - The Properties value
-	 * @returns The same GraphRequest instance that is being called with
+	 * @returns The same GraphRequest instance that is being called with, after adding the properties for $expand query
 	 */
 	public expand(properties: string | string[]): GraphRequest {
 		this.addCsvQueryParameter("$expand", properties, arguments);
@@ -511,7 +512,7 @@ export class GraphRequest {
 	 * @public
 	 * To add properties for orderby OData Query param
 	 * @param {string|string[]} properties - The Properties value
-	 * @returns The same GraphRequest instance that is being called with
+	 * @returns The same GraphRequest instance that is being called with, after adding the properties for $orderby query
 	 */
 	public orderby(properties: string | string[]): GraphRequest {
 		this.addCsvQueryParameter("$orderby", properties, arguments);
@@ -522,7 +523,7 @@ export class GraphRequest {
 	 * @public
 	 * To add query string for filter OData Query param. The request URL accepts only one $filter Odata Query option and its value is set to the most recently passed filter query string.
 	 * @param {string} filterStr - The filter query string
-	 * @returns The same GraphRequest instance that is being called with
+	 * @returns The same GraphRequest instance that is being called with, after adding the $filter query
 	 */
 	public filter(filterStr: string): GraphRequest {
 		this.urlComponents.oDataQueryParams.$filter = filterStr;
@@ -533,7 +534,7 @@ export class GraphRequest {
 	 * @public
 	 * To add criterion for search OData Query param. The request URL accepts only one $search Odata Query option and its value is set to the most recently passed search criterion string.
 	 * @param {string} searchStr - The search criterion string
-	 * @returns The same GraphRequest instance that is being called with
+	 * @returns The same GraphRequest instance that is being called with, after adding the $search query criteria
 	 */
 	public search(searchStr: string): GraphRequest {
 		this.urlComponents.oDataQueryParams.$search = searchStr;
@@ -544,7 +545,7 @@ export class GraphRequest {
 	 * @public
 	 * To add number for top OData Query param. The request URL accepts only one $top Odata Query option and its value is set to the most recently passed number value.
 	 * @param {number} n - The number value
-	 * @returns The same GraphRequest instance that is being called with
+	 * @returns The same GraphRequest instance that is being called with, after adding the number for $top query
 	 */
 	public top(n: number): GraphRequest {
 		this.urlComponents.oDataQueryParams.$top = n;
@@ -555,7 +556,7 @@ export class GraphRequest {
 	 * @public
 	 * To add number for skip OData Query param. The request URL accepts only one $skip Odata Query option and its value is set to the most recently passed number value.
 	 * @param {number} n - The number value
-	 * @returns The same GraphRequest instance that is being called with
+	 * @returns The same GraphRequest instance that is being called with, after adding the number for the $skip query
 	 */
 	public skip(n: number): GraphRequest {
 		this.urlComponents.oDataQueryParams.$skip = n;
@@ -566,7 +567,7 @@ export class GraphRequest {
 	 * @public
 	 * To add token string for skipToken OData Query param. The request URL accepts only one $skipToken Odata Query option and its value is set to the most recently passed token value.
 	 * @param {string} token - The token value
-	 * @returns The same GraphRequest instance that is being called with
+	 * @returns The same GraphRequest instance that is being called with, after adding the token string for $skipToken query option
 	 */
 	public skipToken(token: string): GraphRequest {
 		this.urlComponents.oDataQueryParams.$skipToken = token;
@@ -577,7 +578,7 @@ export class GraphRequest {
 	 * @public
 	 * To add boolean for count OData Query param. The URL accepts only one $count Odata Query option and its value is set to the most recently passed boolean value.
 	 * @param {boolean} isCount - The count boolean
-	 * @returns The same GraphRequest instance that is being called with
+	 * @returns The same GraphRequest instance that is being called with, after adding the boolean value for the $count query option
 	 */
 	public count(isCount: boolean = false): GraphRequest {
 		this.urlComponents.oDataQueryParams.$count = isCount.toString();
@@ -588,7 +589,11 @@ export class GraphRequest {
 	 * @public
 	 * Appends query string to the urlComponent
 	 * @param {string|KeyValuePairObjectStringNumber} queryDictionaryOrString - The query value
-	 * @returns The same GraphRequest instance that is being called with
+	 * @returns The same GraphRequest instance that is being called with, after appending the query string to the url component
+	 */
+	/*
+	 * Accepts .query("displayName=xyz")
+	 *     and .select({ name: "value" })
 	 */
 	public query(queryDictionaryOrString: string | KeyValuePairObjectStringNumber): GraphRequest {
 		return this.parseQueryParameter(queryDictionaryOrString);

--- a/src/GraphRequest.ts
+++ b/src/GraphRequest.ts
@@ -423,7 +423,7 @@ export class GraphRequest {
 
 	/**
 	 * @public
-	 * To add query string for filter OData Query param. The request URL accepts only one $filter Odata Query option and it's value is set to the most recently passed filter query string.
+	 * To add query string for filter OData Query param. The request URL accepts only one $filter Odata Query option and its value is set to the most recently passed filter query string.
 	 * @param {string} filterStr - The filter query string
 	 * @returns The same GraphRequest instance that is being called with
 	 */
@@ -434,7 +434,7 @@ export class GraphRequest {
 
 	/**
 	 * @public
-	 * To add criterion for search OData Query param. The request URL accepts only one $search Odata Query option and it's value is set to the most recently passed search criterion string.
+	 * To add criterion for search OData Query param. The request URL accepts only one $search Odata Query option and its value is set to the most recently passed search criterion string.
 	 * @param {string} searchStr - The search criterion string
 	 * @returns The same GraphRequest instance that is being called with
 	 */
@@ -445,7 +445,7 @@ export class GraphRequest {
 
 	/**
 	 * @public
-	 * To add number for top OData Query param. The request URL accepts only one $top Odata Query option and it's value is set to the most recently passed number value.
+	 * To add number for top OData Query param. The request URL accepts only one $top Odata Query option and its value is set to the most recently passed number value.
 	 * @param {number} n - The number value
 	 * @returns The same GraphRequest instance that is being called with
 	 */
@@ -456,7 +456,7 @@ export class GraphRequest {
 
 	/**
 	 * @public
-	 * To add number for skip OData Query param. The request URL accepts only one $skip Odata Query option and it's value is set to the most recently passed number value.
+	 * To add number for skip OData Query param. The request URL accepts only one $skip Odata Query option and its value is set to the most recently passed number value.
 	 * @param {number} n - The number value
 	 * @returns The same GraphRequest instance that is being called with
 	 */
@@ -467,7 +467,7 @@ export class GraphRequest {
 
 	/**
 	 * @public
-	 * To add token string for skipToken OData Query param. The request URL accepts only one $skipToken Odata Query option and it's value is set to the most recently passed token value.
+	 * To add token string for skipToken OData Query param. The request URL accepts only one $skipToken Odata Query option and its value is set to the most recently passed token value.
 	 * @param {string} token - The token value
 	 * @returns The same GraphRequest instance that is being called with
 	 */
@@ -478,7 +478,7 @@ export class GraphRequest {
 
 	/**
 	 * @public
-	 * To add boolean for count OData Query param. The URL accepts only one $count Odata Query option and it's value is set to the most recently passed boolean value.
+	 * To add boolean for count OData Query param. The URL accepts only one $count Odata Query option and its value is set to the most recently passed boolean value.
 	 * @param {boolean} isCount - The count boolean
 	 * @returns The same GraphRequest instance that is being called with
 	 */
@@ -497,10 +497,11 @@ export class GraphRequest {
 		let paramKey: string;
 		let paramValue: string | number;
 		if (typeof queryDictionaryOrString === "string") {
-			const indexOfFirstEquals = queryDictionaryOrString.indexOf("="); // The query key-value pair must be split on the first equals sign to avoid error while parsing nested query parameters
-			const qParams = [queryDictionaryOrString.substring(0, indexOfFirstEquals), queryDictionaryOrString.substring(indexOfFirstEquals + 1, queryDictionaryOrString.length)];
-			paramKey = qParams[0];
-			paramValue = qParams[1];
+			/* The query key-value pair must be split on the first equals sign to avoid errors in parsing nested query parameters.
+			 Example-> "/me?$expand=home($select=city)" */
+			const indexOfFirstEquals = queryDictionaryOrString.indexOf("=");
+			paramKey = queryDictionaryOrString.substring(0, indexOfFirstEquals);
+			paramValue = queryDictionaryOrString.substring(indexOfFirstEquals + 1, queryDictionaryOrString.length);
 		} else {
 			for (const key in queryDictionaryOrString) {
 				if (queryDictionaryOrString.hasOwnProperty(key)) {
@@ -510,7 +511,9 @@ export class GraphRequest {
 			}
 		}
 		if (oDataQueryNames.indexOf(paramKey) !== -1) {
-			this.urlComponents.oDataQueryParams[paramKey] = paramKey === "$expand" || paramKey === "$select" || paramKey === "$orderby" ? (this.urlComponents.oDataQueryParams[paramKey] ? this.urlComponents.oDataQueryParams[paramKey] + "," + paramValue : paramValue) : paramValue;
+			const currentValue = this.urlComponents.oDataQueryParams[paramKey];
+			const isValueAppendable = (paramKey === "$expand" || paramKey === "$select" || paramKey === "$orderby") && currentValue;
+			this.urlComponents.oDataQueryParams[paramKey] = isValueAppendable ? currentValue + "," + paramValue : paramValue;
 		} else {
 			this.urlComponents.otherURLQueryParams[paramKey] = paramValue;
 		}

--- a/src/GraphRequest.ts
+++ b/src/GraphRequest.ts
@@ -512,7 +512,7 @@ export class GraphRequest {
 		}
 		if (oDataQueryNames.indexOf(paramKey) !== -1) {
 			const currentValue = this.urlComponents.oDataQueryParams[paramKey];
-			const isValueAppendable = (paramKey === "$expand" || paramKey === "$select" || paramKey === "$orderby") && currentValue;
+			const isValueAppendable = currentValue && (paramKey === "$expand" || paramKey === "$select" || paramKey === "$orderby");
 			this.urlComponents.oDataQueryParams[paramKey] = isValueAppendable ? currentValue + "," + paramValue : paramValue;
 		} else {
 			this.urlComponents.otherURLQueryParams[paramKey] = paramValue;


### PR DESCRIPTION
[URL parsing failed ](https://github.com/microsoftgraph/msgraph-sdk-javascript/issues/291)  because the parsePath() function did not considering nested query functions. Changed the function to split the query parameters on the first equals sign([ OData Parsing rules](http://docs.oasis-open.org/odata/odata/v4.01/odata-v4.01-part2-url-conventions.html#_Toc31360925)).

Also, added comments to few query option functions mentioning their expected behaviour.