### PR TITLE
Client init with middleware array

### DIFF
--- a/spec/core/Client.ts
+++ b/spec/core/Client.ts
@@ -68,21 +68,17 @@ describe("Client.ts", () => {
 		});
 
 		it("Init middleware using a middleware array", async () => {
-			try {
-				const provider: AuthProvider = (done) => {
-					done(null, "dummy_token");
-				};
-				const authHandler = new AuthenticationHandler(new CustomAuthenticationProvider(provider));
-				const responseBody = "Test response body";
-				const options = new ChaosHandlerOptions(ChaosStrategy.MANUAL, 200, "Testing middleware array", 0, responseBody);
-				const middlewareArray = [authHandler, new ChaosHandler(options)];
-				const client = Client.initWithMiddleware({ middleware: middlewareArray });
+			const provider: AuthProvider = (done) => {
+				done(null, "dummy_token");
+			};
+			const authHandler = new AuthenticationHandler(new CustomAuthenticationProvider(provider));
+			const responseBody = "Test response body";
+			const options = new ChaosHandlerOptions(ChaosStrategy.MANUAL, 200, "Testing middleware array", 0, responseBody);
+			const middlewareArray = [authHandler, new ChaosHandler(options)];
+			const client = Client.initWithMiddleware({ middleware: middlewareArray });
 
-				const response = await client.api("me").get();
-				assert.equal(response, responseBody);
-			} catch (error) {
-				assert.equal(error.name, "InvalidMiddlewareChain");
-			}
+			const response = await client.api("me").get();
+			assert.equal(response, responseBody);
 		});
 	});
 

--- a/spec/core/Client.ts
+++ b/spec/core/Client.ts
@@ -73,7 +73,7 @@ describe("Client.ts", () => {
 			};
 			const authHandler = new AuthenticationHandler(new CustomAuthenticationProvider(provider));
 			const responseBody = "Test response body";
-			const options = new ChaosHandlerOptions(ChaosStrategy.MANUAL, 200, "Testing middleware array", 0, responseBody);
+			const options = new ChaosHandlerOptions(ChaosStrategy.MANUAL, "Testing middleware array", 200, 0, responseBody);
 			const middlewareArray = [authHandler, new ChaosHandler(options)];
 			const client = Client.initWithMiddleware({ middleware: middlewareArray });
 
@@ -88,7 +88,7 @@ describe("Client.ts", () => {
 			const authHandler = new AuthenticationHandler(new CustomAuthenticationProvider(provider));
 
 			const responseBody = "Test response body";
-			const options = new ChaosHandlerOptions(ChaosStrategy.MANUAL, 200, "Testing chained middleware array", 0, responseBody);
+			const options = new ChaosHandlerOptions(ChaosStrategy.MANUAL, "Testing chained middleware array", 200, 0, responseBody);
 			const chaosHandler = new ChaosHandler(options);
 			const telemetryHandler = new TelemetryHandler();
 

--- a/spec/core/HTTPClient.ts
+++ b/spec/core/HTTPClient.ts
@@ -21,7 +21,38 @@ describe("HTTPClient.ts", () => {
 			assert.isDefined(httpClient["middleware"]);
 			assert.equal(httpClient["middleware"], httpMessageHandler);
 		});
+
+		it("Should create an instance and populate middleware member when passing a middleware array", () => {
+			const client = new HTTPClient(...[httpMessageHandler]);
+			assert.isDefined(client["middleware"]);
+			assert.equal(client["middleware"], httpMessageHandler);
+		});
+
+		it("Should throw an error if middleware is undefined", () => {
+			try {
+				const client = new HTTPClient();
+			} catch (error) {
+				assert.equal(error.name, "InvalidMiddlewareChain");
+			}
+		});
+
+		it("Should throw an error if middleware is passed as null", () => {
+			try {
+				const client = new HTTPClient(null);
+			} catch (error) {
+				assert.equal(error.name, "InvalidMiddlewareChain");
+			}
+		});
+
+		it("Should throw an error if middleware is passed as an empty array", () => {
+			try {
+				const client = new HTTPClient(...[]);
+			} catch (error) {
+				assert.equal(error.name, "InvalidMiddlewareChain");
+			}
+		});
 	});
+
 	/* tslint:enable: no-string-literal */
 
 	describe("sendRequest", async () => {

--- a/spec/middleware/MiddlewareFactory.ts
+++ b/spec/middleware/MiddlewareFactory.ts
@@ -1,0 +1,27 @@
+/**
+ * -------------------------------------------------------------------------------------------
+ * Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.
+ * See License in the project root for license information.
+ * -------------------------------------------------------------------------------------------
+ */
+
+import { assert } from "chai";
+
+import { AuthenticationHandler, CustomAuthenticationProvider, HTTPMessageHandler, RedirectHandler, RetryHandler, TelemetryHandler } from "../../src";
+import { AuthProvider } from "../../src/IAuthProvider";
+import { MiddlewareFactory } from "../../src/middleware/MiddlewareFactory";
+
+describe("MiddlewareFactory", () => {
+	it("Should return the default pipeline", () => {
+		const provider: AuthProvider = (done) => {
+			done(null, "dummy_token");
+		};
+		const defaultMiddleWareArray = MiddlewareFactory.getDefaultMiddlewareChain(new CustomAuthenticationProvider(provider));
+
+		assert.isTrue(defaultMiddleWareArray[0] instanceof AuthenticationHandler);
+		assert.isTrue(defaultMiddleWareArray[1] instanceof RetryHandler);
+		assert.isTrue(defaultMiddleWareArray[2] instanceof RedirectHandler);
+		assert.isTrue(defaultMiddleWareArray[3] instanceof TelemetryHandler);
+		assert.isTrue(defaultMiddleWareArray[4] instanceof HTTPMessageHandler);
+	});
+});

--- a/src/Client.ts
+++ b/src/Client.ts
@@ -93,7 +93,7 @@ export class Client {
 		} else if (clientOptions.authProvider !== undefined) {
 			httpClient = HTTPClientFactory.createWithAuthenticationProvider(clientOptions.authProvider);
 		} else if (clientOptions.middleware !== undefined) {
-			httpClient = new HTTPClient(clientOptions.middleware);
+			httpClient = new HTTPClient(...[].concat(clientOptions.middleware));
 		} else {
 			const error = new Error();
 			error.name = "InvalidMiddlewareChain";

--- a/src/HTTPClient.ts
+++ b/src/HTTPClient.ts
@@ -30,6 +30,12 @@ export class HTTPClient {
 	 * @param {...Middleware} middleware - The first middleware of the middleware chain or a sequence of all the Middleware handlers
 	 */
 	public constructor(...middleware: Middleware[]) {
+		if (!middleware || !middleware.length) {
+			const error = new Error();
+			error.name = "InvalidMiddlewareChain";
+			error.message = "Please provide a default middleware chain or custom middleware chain";
+			throw error;
+		}
 		this.setMiddleware(...middleware);
 	}
 
@@ -39,7 +45,6 @@ export class HTTPClient {
 	 * @param {...Middleware} middleware - The middleware passed
 	 * @returns Nothing
 	 */
-
 	private setMiddleware(...middleware: Middleware[]): void {
 		if (middleware.length > 1) {
 			this.parseMiddleWareArray(middleware);

--- a/src/HTTPClient.ts
+++ b/src/HTTPClient.ts
@@ -27,24 +27,24 @@ export class HTTPClient {
 	 * @public
 	 * @constructor
 	 * Creates an instance of a HTTPClient
-	 * @param {Middleware| Middleware[]} middleware - The first middleware of the middleware chain or the array of middleware handlers
+	 * @param {...Middleware} middleware - The first middleware of the middleware chain or a sequence of all the Middleware handlers
 	 */
-	public constructor(middleware: Middleware | Middleware[]) {
-		this.setMiddleware(middleware);
+	public constructor(...middleware: Middleware[]) {
+		this.setMiddleware(...middleware);
 	}
 
 	/**
 	 * @private
-	 * Verifies if the middleware passed is an array or not before setting this.middleware property
-	 * @param {any} middleware - The middleware passed
+	 * Processes the middleware parameter passed to set this.middleware property
+	 * @param {...Middleware} middleware - The middleware passed
 	 * @returns Nothing
 	 */
 
-	private setMiddleware(middleware: any): void {
-		if (Object.prototype.toString.call(middleware) === "[object Array]") {
+	private setMiddleware(...middleware: Middleware[]): void {
+		if (middleware.length > 1) {
 			this.parseMiddleWareArray(middleware);
 		} else {
-			this.middleware = middleware;
+			this.middleware = middleware[0];
 		}
 	}
 

--- a/src/HTTPClient.ts
+++ b/src/HTTPClient.ts
@@ -29,8 +29,21 @@ export class HTTPClient {
 	 * Creates an instance of a HTTPClient
 	 * @param {Middleware} middleware - The first middleware of the middleware chain
 	 */
-	public constructor(middleware: Middleware) {
-		this.middleware = middleware;
+	public constructor(middleware: Middleware | Middleware[]) {
+		if (Array.isArray(middleware)) {
+			this.parseMiddleWareArray(middleware);
+		} else {
+			this.middleware = middleware;
+		}
+	}
+
+	public parseMiddleWareArray(middlewareArray: Middleware[]) {
+		middlewareArray.forEach((middleware, index) => {
+			if (index < middlewareArray.length - 1) {
+				middleware.setNext(this.middleware[index + 1]);
+			}
+		});
+		this.middleware = middlewareArray[0];
 	}
 
 	/**

--- a/src/HTTPClient.ts
+++ b/src/HTTPClient.ts
@@ -27,20 +27,38 @@ export class HTTPClient {
 	 * @public
 	 * @constructor
 	 * Creates an instance of a HTTPClient
-	 * @param {Middleware} middleware - The first middleware of the middleware chain
+	 * @param {Middleware| Middleware[]} middleware - The first middleware of the middleware chain or the array of middleware handlers
 	 */
 	public constructor(middleware: Middleware | Middleware[]) {
-		if (Array.isArray(middleware)) {
+		this.setMiddleware(middleware);
+	}
+
+	/**
+	 * @private
+	 * Verifies if the middleware passed is an array or not before setting this.middleware property
+	 * @param {any} middleware - The middleware passed
+	 * @returns Nothing
+	 */
+
+	private setMiddleware(middleware: any): void {
+		if (Object.prototype.toString.call(middleware) === "[object Array]") {
 			this.parseMiddleWareArray(middleware);
 		} else {
 			this.middleware = middleware;
 		}
 	}
 
-	public parseMiddleWareArray(middlewareArray: Middleware[]) {
-		middlewareArray.forEach((middleware, index) => {
+	/**
+	 * @private
+	 * Processes the middleware array to construct the chain
+	 * and sets this.middleware property to the first middlware handler of the array
+	 * @param {Middleware[]} middlewareArray - The array of middleware handlers
+	 * @returns Nothing
+	 */
+	private parseMiddleWareArray(middlewareArray: Middleware[]) {
+		middlewareArray.forEach((element, index) => {
 			if (index < middlewareArray.length - 1) {
-				middleware.setNext(this.middleware[index + 1]);
+				element.setNext(middlewareArray[index + 1]);
 			}
 		});
 		this.middleware = middlewareArray[0];

--- a/src/HTTPClientFactory.ts
+++ b/src/HTTPClientFactory.ts
@@ -73,6 +73,7 @@ export class HTTPClientFactory {
 	 * @returns A HTTPClient instance
 	 */
 	public static createWithMiddleware(...middleware: Middleware[]): HTTPClient {
+		// Middleware should not empty or undefined. This is check is present in the HTTPClient constructor.
 		return new HTTPClient(...middleware);
 	}
 }

--- a/src/HTTPClientFactory.ts
+++ b/src/HTTPClientFactory.ts
@@ -26,7 +26,7 @@ import { TelemetryHandler } from "./middleware/TelemetryHandler";
  * @returns A boolean representing the environment is node or not
  */
 const isNodeEnvironment = (): boolean => {
-	return new Function("try {return this === global;}catch(e){return false;}")(); // tslint:disable-line: function-constructor
+	return typeof process === "object" && typeof require === "function";
 };
 
 /**

--- a/src/HTTPClientFactory.ts
+++ b/src/HTTPClientFactory.ts
@@ -69,10 +69,10 @@ export class HTTPClientFactory {
 	 * @public
 	 * @static
 	 * Creates a middleware chain with the given one
-	 * @property {Middleware| Middleware[]} [middleware] - The first middleware of the middleware chain or an array of the Middleware handlers
+	 * @property {...Middleware} middleware - The first middleware of the middleware chain or a sequence of all the Middleware handlers
 	 * @returns A HTTPClient instance
 	 */
-	public static createWithMiddleware(middleware: Middleware | Middleware[]): HTTPClient {
-		return new HTTPClient(middleware);
+	public static createWithMiddleware(...middleware: Middleware[]): HTTPClient {
+		return new HTTPClient(...middleware);
 	}
 }

--- a/src/HTTPClientFactory.ts
+++ b/src/HTTPClientFactory.ts
@@ -69,10 +69,10 @@ export class HTTPClientFactory {
 	 * @public
 	 * @static
 	 * Creates a middleware chain with the given one
-	 * @param {Middleware} middleware - The first middleware of the middleware chain
+	 * @property {Middleware| Middleware[]} [middleware] - The first middleware of the middleware chain or an array of the Middleware handlers
 	 * @returns A HTTPClient instance
 	 */
-	public static createWithMiddleware(middleware: Middleware): HTTPClient {
+	public static createWithMiddleware(middleware: Middleware | Middleware[]): HTTPClient {
 		return new HTTPClient(middleware);
 	}
 }

--- a/src/IClientOptions.ts
+++ b/src/IClientOptions.ts
@@ -17,7 +17,7 @@ import { Middleware } from "./middleware/IMiddleware";
  * @property {boolean} [debugLogging] - The boolean to enable/disable debug logging
  * @property {string} [defaultVersion] - The default version that needs to be used while making graph api request
  * @property {FetchOptions} [fetchOptions] - The options for fetch request
- * @property {Middleware} [middleware] - The first middleware of the middleware chain
+ * @property {Middleware| Middleware[]} [middleware] - The first middleware of the middleware chain or  ordered array of the Middlewares
  */
 export interface ClientOptions {
 	authProvider?: AuthenticationProvider;
@@ -25,5 +25,5 @@ export interface ClientOptions {
 	debugLogging?: boolean;
 	defaultVersion?: string;
 	fetchOptions?: FetchOptions;
-	middleware?: Middleware;
+	middleware?: Middleware | Middleware[];
 }

--- a/src/IClientOptions.ts
+++ b/src/IClientOptions.ts
@@ -17,7 +17,7 @@ import { Middleware } from "./middleware/IMiddleware";
  * @property {boolean} [debugLogging] - The boolean to enable/disable debug logging
  * @property {string} [defaultVersion] - The default version that needs to be used while making graph api request
  * @property {FetchOptions} [fetchOptions] - The options for fetch request
- * @property {Middleware| Middleware[]} [middleware] - The first middleware of the middleware chain or  ordered array of the Middlewares
+ * @property {Middleware| Middleware[]} [middleware] - The first middleware of the middleware chain or an array of the Middleware handlers
  */
 export interface ClientOptions {
 	authProvider?: AuthenticationProvider;

--- a/src/browser/index.ts
+++ b/src/browser/index.ts
@@ -13,17 +13,21 @@ export * from "../middleware/HTTPMessageHandler";
 export * from "../middleware/IMiddleware";
 export * from "../middleware/RetryHandler";
 export * from "../middleware/TelemetryHandler";
-
+export * from "../middleware/MiddlewareFactory";
 export * from "../middleware/options/AuthenticationHandlerOptions";
 export * from "../middleware/options/IMiddlewareOptions";
 export * from "../middleware/options/RetryHandlerOptions";
 export * from "../middleware/options/TelemetryHandlerOptions";
+export * from "../middleware/options/ChaosHandlerOptions";
+export * from "../middleware/options/ChaosStrategy";
+export * from "../middleware/ChaosHandler";
 
 export * from "../tasks/LargeFileUploadTask";
 export * from "../tasks/OneDriveLargeFileUploadTask";
 export * from "../tasks/PageIterator";
 
 export * from "../Client";
+export * from "../CustomAuthenticationProvider";
 export * from "../GraphError";
 export * from "../GraphRequest";
 export * from "../IAuthProvider";

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,7 @@ export * from "./middleware/IMiddleware";
 export * from "./middleware/RetryHandler";
 export * from "./middleware/RedirectHandler";
 export * from "./middleware/TelemetryHandler";
-
+export * from "./middleware/MiddlewareFactory";
 export * from "./middleware/options/AuthenticationHandlerOptions";
 export * from "./middleware/options/IMiddlewareOptions";
 export * from "./middleware/options/RetryHandlerOptions";
@@ -26,6 +26,7 @@ export * from "./tasks/OneDriveLargeFileUploadTask";
 export * from "./tasks/PageIterator";
 
 export * from "./Client";
+export * from "./CustomAuthenticationProvider";
 export * from "./GraphError";
 export * from "./GraphRequest";
 export * from "./IAuthProvider";

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,6 +20,9 @@ export * from "./middleware/options/IMiddlewareOptions";
 export * from "./middleware/options/RetryHandlerOptions";
 export * from "./middleware/options/RedirectHandlerOptions";
 export * from "./middleware/options/TelemetryHandlerOptions";
+export * from "./middleware/options/ChaosHandlerOptions";
+export * from "./middleware/options/ChaosStrategy";
+export * from "./middleware/ChaosHandler";
 
 export * from "./tasks/LargeFileUploadTask";
 export * from "./tasks/OneDriveLargeFileUploadTask";

--- a/src/middleware/MiddlewareFactory.ts
+++ b/src/middleware/MiddlewareFactory.ts
@@ -26,7 +26,7 @@ import { TelemetryHandler } from "./TelemetryHandler";
  * @returns A boolean representing the environment is node or not
  */
 const isNodeEnvironment = (): boolean => {
-	return new Function("try {return this === global;}catch(e){return false;}")(); // tslint:disable-line: function-constructor
+	return typeof process === "object" && typeof require === "function";
 };
 
 /**

--- a/src/middleware/MiddlewareFactory.ts
+++ b/src/middleware/MiddlewareFactory.ts
@@ -1,0 +1,62 @@
+/**
+ * -------------------------------------------------------------------------------------------
+ * Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.
+ * See License in the project root for license information.
+ * -------------------------------------------------------------------------------------------
+ */
+
+/**
+ * @module MiddlewareFactory
+ */
+
+import { AuthenticationProvider } from "../IAuthenticationProvider";
+
+import { AuthenticationHandler } from "./AuthenticationHandler";
+import { HTTPMessageHandler } from "./HTTPMessageHandler";
+import { Middleware } from "./IMiddleware";
+import { RedirectHandlerOptions } from "./options/RedirectHandlerOptions";
+import { RetryHandlerOptions } from "./options/RetryHandlerOptions";
+import { RedirectHandler } from "./RedirectHandler";
+import { RetryHandler } from "./RetryHandler";
+import { TelemetryHandler } from "./TelemetryHandler";
+
+/**
+ * @private
+ * To check whether the environment is node or not
+ * @returns A boolean representing the environment is node or not
+ */
+const isNodeEnvironment = (): boolean => {
+	return new Function("try {return this === global;}catch(e){return false;}")(); // tslint:disable-line: function-constructor
+};
+
+/**
+ * @class
+ * Class containing function(s) related to the middleware pipelines.
+ */
+export class MiddlewareFactory {
+	/**
+	 * @public
+	 * @static
+	 * Returns the default middleware chain an array with the  middleware handlers
+	 * @param {AuthenticationProvider} authProvider - The authentication provider instance
+	 * @returns an array of the middleware handlers of the default middleware chain
+	 */
+	public static getDefaultMiddlewareChain(authProvider: AuthenticationProvider): Middleware[] {
+		const middleware: Middleware[] = new Array();
+		const authenticationHandler = new AuthenticationHandler(authProvider);
+		const retryHandler = new RetryHandler(new RetryHandlerOptions());
+		const telemetryHandler = new TelemetryHandler();
+		const httpMessageHandler = new HTTPMessageHandler();
+
+		middleware.push(authenticationHandler);
+		middleware.push(retryHandler);
+		if (isNodeEnvironment()) {
+			const redirectHandler = new RedirectHandler(new RedirectHandlerOptions());
+			middleware.push(redirectHandler);
+		}
+		middleware.push(telemetryHandler);
+		middleware.push(httpMessageHandler);
+
+		return middleware;
+	}
+}

--- a/src/middleware/MiddlewareFactory.ts
+++ b/src/middleware/MiddlewareFactory.ts
@@ -42,7 +42,7 @@ export class MiddlewareFactory {
 	 * @returns an array of the middleware handlers of the default middleware chain
 	 */
 	public static getDefaultMiddlewareChain(authProvider: AuthenticationProvider): Middleware[] {
-		const middleware: Middleware[] = new Array();
+		const middleware: Middleware[] = [];
 		const authenticationHandler = new AuthenticationHandler(authProvider);
 		const retryHandler = new RetryHandler(new RetryHandlerOptions());
 		const telemetryHandler = new TelemetryHandler();

--- a/src/tasks/OneDriveLargeFileUploadTask.ts
+++ b/src/tasks/OneDriveLargeFileUploadTask.ts
@@ -61,7 +61,10 @@ export class OneDriveLargeFileUploadTask extends LargeFileUploadTask {
 		}
 		// we choose to encode each component of the file path separately because when encoding full URI
 		// with encodeURI, special characters like # or % in the file name doesn't get encoded as desired
-		return `/me/drive/root:${path.split('/').map(p => encodeURIComponent(p)).join('/')}${encodeURIComponent(fileName)}:/createUploadSession`;
+		return `/me/drive/root:${path
+			.split("/")
+			.map((p) => encodeURIComponent(p))
+			.join("/")}${encodeURIComponent(fileName)}:/createUploadSession`;
 	}
 
 	/**


### PR DESCRIPTION
The latest preview release 2.1.0-Preview.1 has a features allowing user to create a middleware chain by passing an array([Commit](https://github.com/microsoftgraph/msgraph-sdk-javascript/commit/834fcf3e6bba7433b80370c6ce1a2d17483ae96a)). These changes were later removed from dev([Reverting Commit](https://github.com/microsoftgraph/msgraph-sdk-javascript/commit/aa17391479985c8cbe4ab4eb0093672a4db79aa2)). 

After a discussion with @darrelmiller and @MIchaelMainer, we planned to allow the user to pass an array of middleware  handlers while initializing the client.  This PR contains these changes.

After this PR is merged, I will be releasing a 2.1.0-Preview.2.