### PR TITLE
Setting GraphError prototype explicity. Version 2.1.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@microsoft/microsoft-graph-client",
-	"version": "2.1.0",
+	"version": "2.1.1",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@microsoft/microsoft-graph-client",
-	"version": "2.1.0",
+	"version": "2.1.1",
 	"description": "Microsoft Graph Client Library",
 	"license": "MIT",
 	"main": "lib/src/index.js",

--- a/spec/core/GraphErrorHandler.ts
+++ b/spec/core/GraphErrorHandler.ts
@@ -7,6 +7,7 @@
 
 import { assert } from "chai";
 
+import { GraphError } from "../../src";
 import { GraphErrorHandler } from "../../src/GraphErrorHandler";
 
 describe("GraphErrorHandler.ts", () => {
@@ -41,6 +42,7 @@ describe("GraphErrorHandler.ts", () => {
 
 		it("Should construct error for error response without innerError property", () => {
 			const gError = GraphErrorHandler["constructErrorFromResponse"](error, statusCode);
+			assert.isTrue(gError instanceof GraphError);
 			assert.equal(gError.statusCode, statusCode);
 			assert.equal(gError.requestId, null);
 		});
@@ -50,6 +52,7 @@ describe("GraphErrorHandler.ts", () => {
 				"request-id": "some random id",
 			};
 			const gError = GraphErrorHandler["constructErrorFromResponse"](error, statusCode);
+			assert.isTrue(gError instanceof GraphError);
 			assert.equal(gError.statusCode, statusCode);
 			assert.equal(gError.requestId, "some random id");
 		});
@@ -62,6 +65,7 @@ describe("GraphErrorHandler.ts", () => {
 				date,
 			};
 			const gError = GraphErrorHandler["constructErrorFromResponse"](error, statusCode);
+			assert.isTrue(gError instanceof GraphError);
 			assert.equal(gError.statusCode, statusCode);
 			assert.equal(gError.requestId, "some random id");
 			assert.equal(gError.date.toUTCString(), date.toUTCString());
@@ -81,6 +85,7 @@ describe("GraphErrorHandler.ts", () => {
 				},
 			};
 			const gError = await GraphErrorHandler.getError(errorResponse);
+			assert.isTrue(gError instanceof GraphError);
 			assert.equal(gError.requestId, "some random id");
 			assert.equal(gError.code, "500");
 			assert.equal(gError.message, "Internal Server Error");
@@ -90,6 +95,7 @@ describe("GraphErrorHandler.ts", () => {
 			const error = new Error("Some Error");
 			error.name = "InvalidError";
 			const gError = await GraphErrorHandler.getError(error);
+			assert.isTrue(gError instanceof GraphError);
 			assert.equal(gError.requestId, null);
 			assert.equal(gError.message, "Some Error");
 			assert.equal(gError.code, "InvalidError");
@@ -97,6 +103,7 @@ describe("GraphErrorHandler.ts", () => {
 
 		it("Should construct some default error", async () => {
 			const gError = await GraphErrorHandler.getError();
+			assert.isTrue(gError instanceof GraphError);
 			assert.equal(gError.message, "");
 			assert.equal(gError.statusCode, -1);
 			assert.equal(gError.code, null);

--- a/src/GraphError.ts
+++ b/src/GraphError.ts
@@ -57,6 +57,8 @@ export class GraphError extends Error {
 	 */
 	public constructor(statusCode: number = -1, message?: string, baseError?: Error) {
 		super(message || (baseError && baseError.message));
+		// https://github.com/Microsoft/TypeScript/wiki/Breaking-Changes#extending-built-ins-like-error-array-and-map-may-no-longer-work
+		Object.setPrototypeOf(this, GraphError.prototype);
 		this.statusCode = statusCode;
 		this.code = null;
 		this.requestId = null;

--- a/src/Version.ts
+++ b/src/Version.ts
@@ -12,4 +12,4 @@
  * @module Version
  */
 
-export const PACKAGE_VERSION = "2.1.0";
+export const PACKAGE_VERSION = "2.1.1";


### PR DESCRIPTION
https://github.com/microsoftgraph/msgraph-sdk-javascript/pull/335#issuecomment-712553311
https://stackoverflow.com/questions/41102060/typescript-extending-error-class

- Creating a version 2.1.1 to fix the breaking change introduced in version 2.1.0. 

- Branching of the master branch here. 