### PR TITLE
Adding/Deleting authorization and telemetry headers

### DIFF
--- a/spec/core/urlParsing.ts
+++ b/spec/core/urlParsing.ts
@@ -43,6 +43,10 @@ const testCases = {
 	"/me/$filter=any(Actors, it/ID eq Director/ID)": "https://graph.microsoft.com/v1.0/me/$filter=any(Actors, it/ID eq Director/ID)",
 	"/me?$whatif": "https://graph.microsoft.com/v1.0/me?$whatif",
 	"/me/?$filter=any(Actors a, any(a/Movies m, a/ID eq m/Director/ID))": "https://graph.microsoft.com/v1.0/me/?$filter=any(Actors a, any(a/Movies m, a/ID eq m/Director/ID))",
+
+	// National cloud deployment urls
+	"https://graph.microsoft.us/v1.0/me": "https://graph.microsoft.us/v1.0/me",
+	"https://dod-graph.microsoft.us/beta/me?$filter=a": "https://dod-graph.microsoft.us/beta/me?$filter=a",
 };
 
 describe("urlParsing.ts", () => {

--- a/spec/middleware/TelemetryHandler.ts
+++ b/spec/middleware/TelemetryHandler.ts
@@ -7,6 +7,7 @@
 
 import { assert } from "chai";
 
+import { GRAPH_BASE_URL } from "../../src/Constants";
 import { Context } from "../../src/IContext";
 import { MiddlewareControl } from "../../src/middleware/MiddlewareControl";
 import { FeatureUsageFlag, TelemetryHandlerOptions } from "../../src/middleware/options/TelemetryHandlerOptions";
@@ -29,7 +30,7 @@ describe("TelemetryHandler.ts", () => {
 			try {
 				const uuid = "dummy_uuid";
 				const context: Context = {
-					request: "url",
+					request: GRAPH_BASE_URL,
 					options: {
 						headers: {
 							"client-request-id": uuid,
@@ -47,7 +48,7 @@ describe("TelemetryHandler.ts", () => {
 		it("Should create client-request-id if one is not present in the request header", async () => {
 			try {
 				const context: Context = {
-					request: "url",
+					request: "https://GRAPH.microsoft.com:443/",
 					options: {
 						headers: {
 							method: "GET",
@@ -65,7 +66,7 @@ describe("TelemetryHandler.ts", () => {
 		it("Should set sdk version header without feature flag usage if telemetry options is not present", async () => {
 			try {
 				const context: Context = {
-					request: "url",
+					request: GRAPH_BASE_URL,
 					options: {
 						headers: {
 							method: "GET",
@@ -85,7 +86,7 @@ describe("TelemetryHandler.ts", () => {
 				const telemetryOptions = new TelemetryHandlerOptions();
 				telemetryOptions["setFeatureUsage"](FeatureUsageFlag.AUTHENTICATION_HANDLER_ENABLED);
 				const context: Context = {
-					request: "url",
+					request: GRAPH_BASE_URL,
 					options: {
 						headers: {
 							method: "GET",
@@ -96,6 +97,27 @@ describe("TelemetryHandler.ts", () => {
 				dummyHTTPHandler.setResponses([okayResponse]);
 				await telemetryHandler.execute(context);
 				assert.equal(context.options.headers["SdkVersion"], `graph-js/${PACKAGE_VERSION} (featureUsage=${FeatureUsageFlag.AUTHENTICATION_HANDLER_ENABLED.toString(16)})`);
+			} catch (error) {
+				throw error;
+			}
+		});
+
+		it("Should not set telemetry for non-graph url", async () => {
+			try {
+				const context: Context = {
+					request: "test url",
+					options: {
+						headers: {
+							method: "GET",
+						},
+					},
+					middlewareControl: new MiddlewareControl(),
+				};
+				dummyHTTPHandler.setResponses([okayResponse]);
+				await telemetryHandler.execute(context);
+				assert.equal(context.options.headers["client-request-id"], undefined);
+				assert.equal(context.options.headers["SdkVersion"], undefined);
+				assert.equal(context.options.headers["setFeatureUsage"], undefined);
 			} catch (error) {
 				throw error;
 			}

--- a/spec/middleware/TelemetryHandler.ts
+++ b/spec/middleware/TelemetryHandler.ts
@@ -27,100 +27,80 @@ describe("TelemetryHandler.ts", () => {
 			statusText: "OK",
 		});
 		it("Should not disturb client-request-id in the header", async () => {
-			try {
-				const uuid = "dummy_uuid";
-				const context: Context = {
-					request: GRAPH_BASE_URL,
-					options: {
-						headers: {
-							"client-request-id": uuid,
-						},
+			const uuid = "dummy_uuid";
+			const context: Context = {
+				request: GRAPH_BASE_URL,
+				options: {
+					headers: {
+						"client-request-id": uuid,
 					},
-				};
-				dummyHTTPHandler.setResponses([okayResponse]);
-				await telemetryHandler.execute(context);
-				assert.equal(context.options.headers["client-request-id"], uuid);
-			} catch (error) {
-				throw error;
-			}
+				},
+			};
+			dummyHTTPHandler.setResponses([okayResponse]);
+			await telemetryHandler.execute(context);
+			assert.equal(context.options.headers["client-request-id"], uuid);
 		});
 
 		it("Should create client-request-id if one is not present in the request header", async () => {
-			try {
-				const context: Context = {
-					request: "https://GRAPH.microsoft.com:443/",
-					options: {
-						headers: {
-							method: "GET",
-						},
+			const context: Context = {
+				request: "https://GRAPH.microsoft.com:443/",
+				options: {
+					headers: {
+						method: "GET",
 					},
-				};
-				dummyHTTPHandler.setResponses([okayResponse]);
-				await telemetryHandler.execute(context);
-				assert.isDefined(context.options.headers["client-request-id"]);
-			} catch (error) {
-				throw error;
-			}
+				},
+			};
+			dummyHTTPHandler.setResponses([okayResponse]);
+			await telemetryHandler.execute(context);
+			assert.isDefined(context.options.headers["client-request-id"]);
 		});
 
 		it("Should set sdk version header without feature flag usage if telemetry options is not present", async () => {
-			try {
-				const context: Context = {
-					request: GRAPH_BASE_URL,
-					options: {
-						headers: {
-							method: "GET",
-						},
+			const context: Context = {
+				request: GRAPH_BASE_URL,
+				options: {
+					headers: {
+						method: "GET",
 					},
-				};
-				dummyHTTPHandler.setResponses([okayResponse]);
-				await telemetryHandler.execute(context);
-				assert.equal(context.options.headers["SdkVersion"], `graph-js/${PACKAGE_VERSION}`);
-			} catch (error) {
-				throw error;
-			}
+				},
+			};
+			dummyHTTPHandler.setResponses([okayResponse]);
+			await telemetryHandler.execute(context);
+			assert.equal(context.options.headers["SdkVersion"], `graph-js/${PACKAGE_VERSION}`);
 		});
 
 		it("Should set sdk version header with feature flag", async () => {
-			try {
-				const telemetryOptions = new TelemetryHandlerOptions();
-				telemetryOptions["setFeatureUsage"](FeatureUsageFlag.AUTHENTICATION_HANDLER_ENABLED);
-				const context: Context = {
-					request: GRAPH_BASE_URL,
-					options: {
-						headers: {
-							method: "GET",
-						},
+			const telemetryOptions = new TelemetryHandlerOptions();
+			telemetryOptions["setFeatureUsage"](FeatureUsageFlag.AUTHENTICATION_HANDLER_ENABLED);
+			const context: Context = {
+				request: GRAPH_BASE_URL,
+				options: {
+					headers: {
+						method: "GET",
 					},
-					middlewareControl: new MiddlewareControl([telemetryOptions]),
-				};
-				dummyHTTPHandler.setResponses([okayResponse]);
-				await telemetryHandler.execute(context);
-				assert.equal(context.options.headers["SdkVersion"], `graph-js/${PACKAGE_VERSION} (featureUsage=${FeatureUsageFlag.AUTHENTICATION_HANDLER_ENABLED.toString(16)})`);
-			} catch (error) {
-				throw error;
-			}
+				},
+				middlewareControl: new MiddlewareControl([telemetryOptions]),
+			};
+			dummyHTTPHandler.setResponses([okayResponse]);
+			await telemetryHandler.execute(context);
+			assert.equal(context.options.headers["SdkVersion"], `graph-js/${PACKAGE_VERSION} (featureUsage=${FeatureUsageFlag.AUTHENTICATION_HANDLER_ENABLED.toString(16)})`);
 		});
 
 		it("Should not set telemetry for non-graph url", async () => {
-			try {
-				const context: Context = {
-					request: "test url",
-					options: {
-						headers: {
-							method: "GET",
-						},
+			const context: Context = {
+				request: "test url",
+				options: {
+					headers: {
+						method: "GET",
 					},
-					middlewareControl: new MiddlewareControl(),
-				};
-				dummyHTTPHandler.setResponses([okayResponse]);
-				await telemetryHandler.execute(context);
-				assert.equal(context.options.headers["client-request-id"], undefined);
-				assert.equal(context.options.headers["SdkVersion"], undefined);
-				assert.equal(context.options.headers["setFeatureUsage"], undefined);
-			} catch (error) {
-				throw error;
-			}
+				},
+				middlewareControl: new MiddlewareControl(),
+			};
+			dummyHTTPHandler.setResponses([okayResponse]);
+			await telemetryHandler.execute(context);
+			assert.equal(context.options.headers["client-request-id"], undefined);
+			assert.equal(context.options.headers["SdkVersion"], undefined);
+			assert.equal(context.options.headers["setFeatureUsage"], undefined);
 		});
 	});
 	/* tslint:enable: no-string-literal */

--- a/src/Constants.ts
+++ b/src/Constants.ts
@@ -20,3 +20,9 @@ export const GRAPH_API_VERSION = "v1.0";
  * A Default base url for a request
  */
 export const GRAPH_BASE_URL = "https://graph.microsoft.com/";
+
+/**
+ * To hold list of the service root endpoints for Microsoft Graph and Graph Explorer for each national cloud.
+ * Set(iterable:Object) is not supported in Internet Explorer. The consumer is recommended to use a suitable polyfill.
+ */
+export const GRAPH_URLS = new Set<string>(["graph.microsoft.com", "graph.microsoft.us", "dod-graph.microsoft.us", "graph.microsoft.de", "microsoftgraph.chinacloudapi.cn"]);

--- a/src/GraphRequestUtil.ts
+++ b/src/GraphRequestUtil.ts
@@ -58,3 +58,41 @@ export const serializeContent = (content: any): any => {
 	}
 	return content;
 };
+/**
+ * To hold list of the service root endpoints for Microsoft Graph and Graph Explorer for each national cloud.
+ */
+export const graphURLs = new Set<string>();
+
+// using an IIFE to populate the set object with the graph host names as Set(iterable:Object) is not supported in Internet Explorer
+(() => {
+	const urls = ["graph.microsoft.com", "graph.microsoft.us", "dod-graph.microsoft.us", "graph.microsoft.de", "microsoftgraph.chinacloudapi.cn"];
+	urls.forEach((url) => {
+		graphURLs.add(url);
+	});
+})();
+
+export const isGraphURL = (url: string): boolean => {
+	// Valid Graph URL pattern - https://graph.microsoft.com/{version}/{resource}?{query-parameters}
+	// Valid Graph URL example - https://graph.microsoft.com/v1.0/
+	url = url.toLowerCase();
+
+	if (url.indexOf("https://") !== -1) {
+		url = url.replace("https://", "");
+
+		// Find where the host ends
+		const startofPortNoPos = url.indexOf(":");
+		const endOfHostStrPos = url.indexOf("/");
+		let hostName = "";
+		if (endOfHostStrPos !== -1) {
+			if (startofPortNoPos !== -1 && startofPortNoPos < endOfHostStrPos) {
+				hostName = url.substring(0, startofPortNoPos);
+				return graphURLs.has(hostName);
+			}
+			// Parse out the host
+			hostName = url.substring(0, endOfHostStrPos);
+			return graphURLs.has(hostName);
+		}
+	}
+
+	return false;
+};

--- a/src/GraphRequestUtil.ts
+++ b/src/GraphRequestUtil.ts
@@ -8,7 +8,7 @@
 /**
  * @module GraphRequestUtil
  */
-
+import { GRAPH_URLS } from "./Constants";
 /**
  * To hold list of OData query params
  */
@@ -58,11 +58,6 @@ export const serializeContent = (content: any): any => {
 	}
 	return content;
 };
-/**
- * To hold list of the service root endpoints for Microsoft Graph and Graph Explorer for each national cloud.
- * Set(iterable:Object) is not supported in Internet Explorer. The consumer is recommended to use a suitable polyfill.
- */
-export const graphURLs = new Set<string>(["graph.microsoft.com", "graph.microsoft.us", "dod-graph.microsoft.us", "graph.microsoft.de", "microsoftgraph.chinacloudapi.cn"]);
 
 /**
  * Checks if the url is one of the service root endpoints for Microsoft Graph and Graph Explorer.
@@ -84,11 +79,11 @@ export const isGraphURL = (url: string): boolean => {
 		if (endOfHostStrPos !== -1) {
 			if (startofPortNoPos !== -1 && startofPortNoPos < endOfHostStrPos) {
 				hostName = url.substring(0, startofPortNoPos);
-				return graphURLs.has(hostName);
+				return GRAPH_URLS.has(hostName);
 			}
 			// Parse out the host
 			hostName = url.substring(0, endOfHostStrPos);
-			return graphURLs.has(hostName);
+			return GRAPH_URLS.has(hostName);
 		}
 	}
 

--- a/src/GraphRequestUtil.ts
+++ b/src/GraphRequestUtil.ts
@@ -71,6 +71,11 @@ export const graphURLs = new Set<string>();
 	});
 })();
 
+/**
+ * Checks if the url is one of the service root endpoints for Microsoft Graph and Graph Explorer.
+ * @param {string} url - The url to be verified
+ * @returns {boolean} - Returns true if the url is a Graph URL
+ */
 export const isGraphURL = (url: string): boolean => {
 	// Valid Graph URL pattern - https://graph.microsoft.com/{version}/{resource}?{query-parameters}
 	// Valid Graph URL example - https://graph.microsoft.com/v1.0/

--- a/src/GraphRequestUtil.ts
+++ b/src/GraphRequestUtil.ts
@@ -60,16 +60,9 @@ export const serializeContent = (content: any): any => {
 };
 /**
  * To hold list of the service root endpoints for Microsoft Graph and Graph Explorer for each national cloud.
+ * Set(iterable:Object) is not supported in Internet Explorer. The consumer is recommended to use a suitable polyfill.
  */
-export const graphURLs = new Set<string>();
-
-// using an IIFE to populate the set object with the graph host names as Set(iterable:Object) is not supported in Internet Explorer
-(() => {
-	const urls = ["graph.microsoft.com", "graph.microsoft.us", "dod-graph.microsoft.us", "graph.microsoft.de", "microsoftgraph.chinacloudapi.cn"];
-	urls.forEach((url) => {
-		graphURLs.add(url);
-	});
-})();
+export const graphURLs = new Set<string>(["graph.microsoft.com", "graph.microsoft.us", "dod-graph.microsoft.us", "graph.microsoft.de", "microsoftgraph.chinacloudapi.cn"]);
 
 /**
  * Checks if the url is one of the service root endpoints for Microsoft Graph and Graph Explorer.

--- a/src/middleware/RedirectHandler.ts
+++ b/src/middleware/RedirectHandler.ts
@@ -201,7 +201,7 @@ export class RedirectHandler implements Middleware {
 					delete context.options.body;
 				} else {
 					const redirectUrl: string = this.getLocationHeader(response);
-					if (!this.isRelativeURL(redirectUrl) && this.shouldDropAuthorizationHeader(response.url, redirectUrl) && context.options.headers[RedirectHandler.AUTHORIZATION_HEADER]) {
+					if (!this.isRelativeURL(redirectUrl) && this.shouldDropAuthorizationHeader(response.url, redirectUrl)) {
 						delete context.options.headers[RedirectHandler.AUTHORIZATION_HEADER];
 					}
 					await this.updateRequestUrl(redirectUrl, context);

--- a/src/middleware/RedirectHandler.ts
+++ b/src/middleware/RedirectHandler.ts
@@ -201,8 +201,8 @@ export class RedirectHandler implements Middleware {
 					delete context.options.body;
 				} else {
 					const redirectUrl: string = this.getLocationHeader(response);
-					if (!this.isRelativeURL(redirectUrl) && this.shouldDropAuthorizationHeader(response.url, redirectUrl)) {
-						setRequestHeader(context.request, context.options, RedirectHandler.AUTHORIZATION_HEADER, undefined);
+					if (!this.isRelativeURL(redirectUrl) && this.shouldDropAuthorizationHeader(response.url, redirectUrl) && context.options.headers[RedirectHandler.AUTHORIZATION_HEADER]) {
+						delete context.options.headers[RedirectHandler.AUTHORIZATION_HEADER];
 					}
 					await this.updateRequestUrl(redirectUrl, context);
 				}

--- a/src/middleware/TelemetryHandler.ts
+++ b/src/middleware/TelemetryHandler.ts
@@ -87,12 +87,8 @@ export class TelemetryHandler implements Middleware {
 					appendRequestHeader(context.request, context.options, TelemetryHandler.SDK_VERSION_HEADER, sdkVersionValue);
 				} else {
 					// Remove telemetry headers if present during redirection.
-					if (context.options.headers[TelemetryHandler.CLIENT_REQUEST_ID_HEADER]) {
-						delete context.options.headers[TelemetryHandler.CLIENT_REQUEST_ID_HEADER];
-					}
-					if (context.options.headers[TelemetryHandler.SDK_VERSION_HEADER]) {
-						delete context.options.headers[TelemetryHandler.SDK_VERSION_HEADER];
-					}
+					delete context.options.headers[TelemetryHandler.CLIENT_REQUEST_ID_HEADER];
+					delete context.options.headers[TelemetryHandler.SDK_VERSION_HEADER];
 				}
 			}
 			return await this.nextMiddleware.execute(context);

--- a/src/middleware/TelemetryHandler.ts
+++ b/src/middleware/TelemetryHandler.ts
@@ -80,7 +80,7 @@ export class TelemetryHandler implements Middleware {
 					if (context.middlewareControl instanceof MiddlewareControl) {
 						options = context.middlewareControl.getMiddlewareOptions(TelemetryHandlerOptions) as TelemetryHandlerOptions;
 					}
-					if (typeof options !== "undefined") {
+					if (options) {
 						const featureUsage: string = options.getFeatureUsage();
 						sdkVersionValue += ` (${TelemetryHandler.FEATURE_USAGE_STRING}=${featureUsage})`;
 					}

--- a/src/middleware/TelemetryHandler.ts
+++ b/src/middleware/TelemetryHandler.ts
@@ -68,6 +68,8 @@ export class TelemetryHandler implements Middleware {
 		try {
 			if (typeof context.request === "string") {
 				if (isGraphURL(context.request)) {
+					// Add telemetry only if the request url is a Graph URL.
+					// Errors are reported as in issue #265 if headers are present when redirecting to a non Graph URL
 					let clientRequestId: string = getRequestHeader(context.request, context.options, TelemetryHandler.CLIENT_REQUEST_ID_HEADER);
 					if (clientRequestId === null) {
 						clientRequestId = generateUUID();
@@ -84,6 +86,7 @@ export class TelemetryHandler implements Middleware {
 					}
 					appendRequestHeader(context.request, context.options, TelemetryHandler.SDK_VERSION_HEADER, sdkVersionValue);
 				} else {
+					// Remove telemetry headers if present during redirection.
 					if (context.options.headers[TelemetryHandler.CLIENT_REQUEST_ID_HEADER]) {
 						delete context.options.headers[TelemetryHandler.CLIENT_REQUEST_ID_HEADER];
 					}

--- a/src/middleware/TelemetryHandler.ts
+++ b/src/middleware/TelemetryHandler.ts
@@ -66,25 +66,31 @@ export class TelemetryHandler implements Middleware {
 	 */
 	public async execute(context: Context): Promise<void> {
 		try {
-			if (typeof context.request === "string" && isGraphURL(context.request)) {
-				let clientRequestId: string = getRequestHeader(context.request, context.options, TelemetryHandler.CLIENT_REQUEST_ID_HEADER);
-				if (clientRequestId === null) {
-					clientRequestId = generateUUID();
-					setRequestHeader(context.request, context.options, TelemetryHandler.CLIENT_REQUEST_ID_HEADER, clientRequestId);
+			if (typeof context.request === "string") {
+				if (isGraphURL(context.request)) {
+					let clientRequestId: string = getRequestHeader(context.request, context.options, TelemetryHandler.CLIENT_REQUEST_ID_HEADER);
+					if (clientRequestId === null) {
+						clientRequestId = generateUUID();
+						setRequestHeader(context.request, context.options, TelemetryHandler.CLIENT_REQUEST_ID_HEADER, clientRequestId);
+					}
+					let sdkVersionValue: string = `${TelemetryHandler.PRODUCT_NAME}/${PACKAGE_VERSION}`;
+					let options: TelemetryHandlerOptions;
+					if (context.middlewareControl instanceof MiddlewareControl) {
+						options = context.middlewareControl.getMiddlewareOptions(TelemetryHandlerOptions) as TelemetryHandlerOptions;
+					}
+					if (typeof options !== "undefined") {
+						const featureUsage: string = options.getFeatureUsage();
+						sdkVersionValue += ` (${TelemetryHandler.FEATURE_USAGE_STRING}=${featureUsage})`;
+					}
+					appendRequestHeader(context.request, context.options, TelemetryHandler.SDK_VERSION_HEADER, sdkVersionValue);
+				} else {
+					if (context.options.headers[TelemetryHandler.CLIENT_REQUEST_ID_HEADER]) {
+						delete context.options.headers[TelemetryHandler.CLIENT_REQUEST_ID_HEADER];
+					}
+					if (context.options.headers[TelemetryHandler.SDK_VERSION_HEADER]) {
+						delete context.options.headers[TelemetryHandler.SDK_VERSION_HEADER];
+					}
 				}
-				let sdkVersionValue: string = `${TelemetryHandler.PRODUCT_NAME}/${PACKAGE_VERSION}`;
-				let options: TelemetryHandlerOptions;
-				if (context.middlewareControl instanceof MiddlewareControl) {
-					options = context.middlewareControl.getMiddlewareOptions(TelemetryHandlerOptions) as TelemetryHandlerOptions;
-				}
-				if (typeof options !== "undefined") {
-					const featureUsage: string = options.getFeatureUsage();
-					sdkVersionValue += ` (${TelemetryHandler.FEATURE_USAGE_STRING}=${featureUsage})`;
-				}
-				appendRequestHeader(context.request, context.options, TelemetryHandler.SDK_VERSION_HEADER, sdkVersionValue);
-			} else {
-				delete context.options.headers[TelemetryHandler.CLIENT_REQUEST_ID_HEADER];
-				delete context.options.headers[TelemetryHandler.SDK_VERSION_HEADER];
 			}
 			return await this.nextMiddleware.execute(context);
 		} catch (error) {


### PR DESCRIPTION
Fixes #265 and #344 

Problem 1 - #265 reports a CORs error which was caused because the SDK added telemetry headers only for every request that goes out. The redirected non-Graph endpoint complained about the unexpected SDK_Version header and caused a CORS error.
Solution for Problem 1 - This PR includes logic to check in the `TelemetryHandler` if the URL is a Graph URL and if yes process to add the telemetry headers. If the URL is a non Graph URL and the telemetry headers are present, then the headers are deleted.

Problem 2 - #344 @peombwa Thank you for helping me reproduce this issue! 
On redirection, the `RedirectionHandler` is currently setting the AuthorizationHeader to undefined instead of completely dropping the header key. 
The existing code worked fine in a node environment but failed when using ExpressJS. 

Solution for Problem 2 - This PR includes change in the `RedirectionHandler` to delete Authorization header key if present.


