### PR TITLE
Checking if the request object url is a graph url

### DIFF
--- a/spec/middleware/TelemetryHandler.ts
+++ b/spec/middleware/TelemetryHandler.ts
@@ -29,7 +29,6 @@ describe("TelemetryHandler.ts", () => {
 			statusText: "OK",
 		});
 		it("Should not disturb client-request-id in the header", async () => {
-			const request = new Request(GRAPH_BASE_URL);
 			const context: Context = {
 				request: GRAPH_BASE_URL,
 				options: {
@@ -105,7 +104,7 @@ describe("TelemetryHandler.ts", () => {
 			assert.equal(context.options.headers["setFeatureUsage"], undefined);
 		});
 
-		it("Should not disturb client-request-id in the header when Request object passed with Graph URL", async () => {
+		it("Should not disturb client-request-id in the header when Request object is passed with Graph URL", async () => {
 			const request = new Request(GRAPH_BASE_URL);
 			const context: Context = {
 				request,
@@ -122,7 +121,7 @@ describe("TelemetryHandler.ts", () => {
 			assert.equal(context.options.headers["SdkVersion"], sdkVersion);
 		});
 
-		it("Should delete Telemetry in the header when Request object passed with non Graph URL", async () => {
+		it("Should delete Telemetry in the header when Request object is passed with non Graph URL", async () => {
 			const request = new Request("test_url");
 			const context: Context = {
 				request,

--- a/src/middleware/TelemetryHandler.ts
+++ b/src/middleware/TelemetryHandler.ts
@@ -71,7 +71,7 @@ export class TelemetryHandler implements Middleware {
 				// Add telemetry only if the request url is a Graph URL.
 				// Errors are reported as in issue #265 if headers are present when redirecting to a non Graph URL
 				let clientRequestId: string = getRequestHeader(context.request, context.options, TelemetryHandler.CLIENT_REQUEST_ID_HEADER);
-				if (clientRequestId === null) {
+				if (!clientRequestId) {
 					clientRequestId = generateUUID();
 					setRequestHeader(context.request, context.options, TelemetryHandler.CLIENT_REQUEST_ID_HEADER, clientRequestId);
 				}

--- a/src/middleware/TelemetryHandler.ts
+++ b/src/middleware/TelemetryHandler.ts
@@ -66,30 +66,29 @@ export class TelemetryHandler implements Middleware {
 	 */
 	public async execute(context: Context): Promise<void> {
 		try {
-			if (typeof context.request === "string") {
-				if (isGraphURL(context.request)) {
-					// Add telemetry only if the request url is a Graph URL.
-					// Errors are reported as in issue #265 if headers are present when redirecting to a non Graph URL
-					let clientRequestId: string = getRequestHeader(context.request, context.options, TelemetryHandler.CLIENT_REQUEST_ID_HEADER);
-					if (clientRequestId === null) {
-						clientRequestId = generateUUID();
-						setRequestHeader(context.request, context.options, TelemetryHandler.CLIENT_REQUEST_ID_HEADER, clientRequestId);
-					}
-					let sdkVersionValue: string = `${TelemetryHandler.PRODUCT_NAME}/${PACKAGE_VERSION}`;
-					let options: TelemetryHandlerOptions;
-					if (context.middlewareControl instanceof MiddlewareControl) {
-						options = context.middlewareControl.getMiddlewareOptions(TelemetryHandlerOptions) as TelemetryHandlerOptions;
-					}
-					if (options) {
-						const featureUsage: string = options.getFeatureUsage();
-						sdkVersionValue += ` (${TelemetryHandler.FEATURE_USAGE_STRING}=${featureUsage})`;
-					}
-					appendRequestHeader(context.request, context.options, TelemetryHandler.SDK_VERSION_HEADER, sdkVersionValue);
-				} else {
-					// Remove telemetry headers if present during redirection.
-					delete context.options.headers[TelemetryHandler.CLIENT_REQUEST_ID_HEADER];
-					delete context.options.headers[TelemetryHandler.SDK_VERSION_HEADER];
+			const url = typeof context.request === "string" ? context.request : context.request.url;
+			if (isGraphURL(url)) {
+				// Add telemetry only if the request url is a Graph URL.
+				// Errors are reported as in issue #265 if headers are present when redirecting to a non Graph URL
+				let clientRequestId: string = getRequestHeader(context.request, context.options, TelemetryHandler.CLIENT_REQUEST_ID_HEADER);
+				if (clientRequestId === null) {
+					clientRequestId = generateUUID();
+					setRequestHeader(context.request, context.options, TelemetryHandler.CLIENT_REQUEST_ID_HEADER, clientRequestId);
 				}
+				let sdkVersionValue: string = `${TelemetryHandler.PRODUCT_NAME}/${PACKAGE_VERSION}`;
+				let options: TelemetryHandlerOptions;
+				if (context.middlewareControl instanceof MiddlewareControl) {
+					options = context.middlewareControl.getMiddlewareOptions(TelemetryHandlerOptions) as TelemetryHandlerOptions;
+				}
+				if (options) {
+					const featureUsage: string = options.getFeatureUsage();
+					sdkVersionValue += ` (${TelemetryHandler.FEATURE_USAGE_STRING}=${featureUsage})`;
+				}
+				appendRequestHeader(context.request, context.options, TelemetryHandler.SDK_VERSION_HEADER, sdkVersionValue);
+			} else {
+				// Remove telemetry headers if present during redirection.
+				delete context.options.headers[TelemetryHandler.CLIENT_REQUEST_ID_HEADER];
+				delete context.options.headers[TelemetryHandler.SDK_VERSION_HEADER];
 			}
 			return await this.nextMiddleware.execute(context);
 		} catch (error) {


### PR DESCRIPTION
in #351, I made changes to add/drop telemetry headers if the request URL is /isn't a Graph URL.

Added one more small change in the `TelemetryHandler` to read the request url from the context.request(which could be a string or a Request object) before checking if the url is a Graph URL or not. 
