### PR TITLE
hotfix/msal dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4362,12 +4362,10 @@
 			"dev": true
 		},
 		"msal": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/msal/-/msal-1.0.0.tgz",
-			"integrity": "sha512-tw1QYtBjRzmxjjrV5q53Oa42APxHq3YpZxlM6n0H4dTwah4Xx3yEIShG03aQUhRHqu0UBk9yHJ5TZreNzMiYdg==",
-			"dev": true,
+			"version": "1.4.4",
+			"resolved": "https://registry.npmjs.org/msal/-/msal-1.4.4.tgz",
+			"integrity": "sha512-aOBD/L6jAsizDFzKxxvXxH0FEDjp6Inr3Ufi/Y2o7KCFKN+akoE2sLeszEb/0Y3VxHxK0F0ea7xQ/HHTomKivw==",
 			"requires": {
-				"atob": "~2.1.1",
 				"tslib": "^1.9.3"
 			}
 		},

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@microsoft/microsoft-graph-client",
-	"version": "2.2.0",
+	"version": "2.2.1",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@microsoft/microsoft-graph-client",
-	"version": "2.2.0",
+	"version": "2.2.1",
 	"description": "Microsoft Graph Client Library",
 	"license": "MIT",
 	"main": "lib/src/index.js",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
 	"types": "./lib/src/index.d.ts",
 	"dependencies": {
 		"@babel/runtime": "^7.4.4",
+		"msal": "^1.4.4",
 		"tslib": "^1.9.3"
 	},
 	"devDependencies": {
@@ -27,7 +28,6 @@
 		"isomorphic-fetch": "^2.2.1",
 		"lint-staged": "^8.1.5",
 		"mocha": "^6.1.4",
-		"msal": "^1.0.0",
 		"prettier": "^1.17.0",
 		"rollup": "^1.10.1",
 		"rollup-plugin-babel": "^4.3.2",

--- a/src/Version.ts
+++ b/src/Version.ts
@@ -12,4 +12,4 @@
  * @module Version
  */
 
-export const PACKAGE_VERSION = "2.2.0";
+export const PACKAGE_VERSION = "2.2.1";


### PR DESCRIPTION
- moves msal dependency to runtime deps
- 2.2.1
fixes #361