### PR TITLE
Propose getDelta function on GraphRequest

### DIFF
--- a/src/GraphRequest.ts
+++ b/src/GraphRequest.ts
@@ -53,15 +53,17 @@ export interface URLComponents {
 }
 
 export type DeltaResponse<T> = {
-    tokenType: "skip",
+    linkType: "next",
     skipToken: string,
-    value: T[],
-    nextRequest: () => Promise<DeltaResponse<T>>,
+    followNextLink: () => Promise<DeltaResponse<T>>,
+    body: any,
 } | {
-    tokenType: "delta",
+    linkType: "delta",
     deltaToken: string,
-    nextRequest: () => Promise<DeltaResponse<T>>,
+    followDeltaLink: () => Promise<DeltaResponse<T>>,
+    body: any,
 };
+
 /**
  * @class
  * A Class representing GraphRequest


### PR DESCRIPTION
## Summary

This aims to encapsulate semantics of the `@odata/nextLink` and `@odata/deltaLink` scheme for delta requests in a new function `getDelta` on the `GraphRequest` class.

## Motivation

Working with a `/delta` endpoint is kind of painful, unless I'm missing something. e.g. here's how one might extract the `skiptoken`:

```typescript
const skipToken = new URL(response["@odata.nextLink"]).searchParams.get("$skiptoken") ?? undefined;
```

I have to do the same for `deltatoken`, then check if either is undefined and then proceed accordingly.

Or ditch the SDK altogether at this point and craft a plain HTTP request to the next/delta link, digging up the auth token to put on there. Sounds like a bummer.

## Test plan

Demonstrate the code is solid. Example: The exact commands you ran and their output.

_TBD - Draft PR for illustrative purposes only.  Will revisit if consensus is reached on the direction of the change._

_I haven't even cloned the repo yet - I just pasted the helper I wrote from my private project in the GitHub web editor and made some tweaks by hand, it does not even build_ :)

## Closing issues

Fixes #407

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

_This is a Draft PR, if there's consensus on the change I will follow-up with a proper PR, checking all these boxes_

-   [x] I have read the **CONTRIBUTING** document.
-   [ ] My code follows the code style of this project.
-   [x] My change requires a change to the documentation.
-   [ ] I have updated the documentation accordingly.
-   [ ] I have added tests to cover my changes.
-   [ ] All new and existing tests passed.
