### PR TITLE
Resume stream upload 

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,6 @@
 		"setVersion": "gulp setVersion",
 		"test": "npm run test:cjs && npm run test:esm",
 		"test:cjs": "npm run build:sub_cjs   && mocha  'lib/test/common/**/*.js' --require  isomorphic-fetch &&  mocha  'lib/test/node/**/*.js' --require  isomorphic-fetch",
-		"test:node": "npm run build:sub_cjs &&  mocha  'lib/test/node/**/*.js' --require  isomorphic-fetch",
 		"test:coverage": "TS_NODE_PROJECT='./tsconfig-cjs.json' nyc mocha --require isomorphic-fetch -r ts-node/register test/common/**/*.ts && mocha --require isomorphic-fetch -r ts-node/register test/common/**/*.ts",
 		"test:development": "tsc --p test/tsconfig-test-development.json &&  mocha  'lib/test/development/**/*.js' --require  isomorphic-fetch",
 		"test:esm": "npm run build:sub_es  && mocha  'lib/es/test/common/**/*.js' --require  esm --require  isomorphic-fetch &&  mocha  'lib/es/test/node/**/*.js' --require  esm --require  isomorphic-fetch"

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
 		"setVersion": "gulp setVersion",
 		"test": "npm run test:cjs && npm run test:esm",
 		"test:cjs": "npm run build:sub_cjs   && mocha  'lib/test/common/**/*.js' --require  isomorphic-fetch &&  mocha  'lib/test/node/**/*.js' --require  isomorphic-fetch",
+		"test:node": "npm run build:sub_cjs &&  mocha  'lib/test/node/**/*.js' --require  isomorphic-fetch",
 		"test:coverage": "TS_NODE_PROJECT='./tsconfig-cjs.json' nyc mocha --require isomorphic-fetch -r ts-node/register test/common/**/*.ts && mocha --require isomorphic-fetch -r ts-node/register test/common/**/*.ts",
 		"test:development": "tsc --p test/tsconfig-test-development.json &&  mocha  'lib/test/development/**/*.js' --require  isomorphic-fetch",
 		"test:esm": "npm run build:sub_es  && mocha  'lib/es/test/common/**/*.js' --require  esm --require  isomorphic-fetch &&  mocha  'lib/es/test/node/**/*.js' --require  esm --require  isomorphic-fetch"

--- a/src/tasks/LargeFileUploadTask.ts
+++ b/src/tasks/LargeFileUploadTask.ts
@@ -41,6 +41,7 @@ interface UploadStatusResponse {
  * @interface
  * Signature to define options for upload task
  * @property {number} [rangeSize = LargeFileUploadTask.DEFAULT_FILE_SIZE] - Specifies the range chunk size
+ * @property {UploadEventHandlers} uploadEventHandlers - UploadEventHandlers attached to an upload task
  */
 export interface LargeFileUploadTaskOptions {
 	rangeSize?: number;

--- a/test/node/tasks/StreamUpload.ts
+++ b/test/node/tasks/StreamUpload.ts
@@ -50,4 +50,20 @@ describe("StreamUpload", () => {
 		assert.isDefined(slice);
 		assert.equal(sliceSize, (slice as Buffer).length);
 	});
+
+	it("Stream resume", async () => {
+		const readStream = fs.createReadStream(filePath, { highWaterMark: totalsize });
+		const sliceSize = 20;
+
+		const upload = new StreamUpload(readStream, fileName, totalsize);
+
+		const slice = await upload.sliceFile({ minValue: 0, maxValue: sliceSize - 1 });
+		const retrySlice = await upload.sliceFile({ minValue: 15, maxValue: 21 });
+		assert.isDefined(slice);
+		assert.isDefined(retrySlice);
+		assert.equal(sliceSize, (slice as Buffer).length);
+
+		console.log(retrySlice);
+		console.log(slice);
+	});
 });

--- a/test/node/tasks/StreamUpload.ts
+++ b/test/node/tasks/StreamUpload.ts
@@ -12,11 +12,12 @@ import * as fs from "fs";
 
 import { StreamUpload } from "../../../src/tasks/FileUploadTask/FileObjectClasses/StreamUpload";
 
+const fileName = "sample_image.jpg";
+const filePath = `./test/sample_files/${fileName}`;
+const stats = fs.statSync(`./test/sample_files/${fileName}`);
+const totalsize = stats.size;
+
 describe("StreamUpload", () => {
-	const fileName = "sample_image.jpg";
-	const filePath = `./test/sample_files/${fileName}`;
-	const stats = fs.statSync(`./test/sample_files/${fileName}`);
-	const totalsize = stats.size;
 	it("Stream size smaller than upload range size", async () => {
 		const readStream = fs.createReadStream(`./test/sample_files/${fileName}`, { highWaterMark: 8 });
 
@@ -50,8 +51,10 @@ describe("StreamUpload", () => {
 		assert.isDefined(slice);
 		assert.equal(sliceSize, (slice as Buffer).length);
 	});
+});
 
-	it("Stream resume", async () => {
+describe("Stream upload resume", () => {
+	it("New range is equal to previous upload range", async () => {
 		const readStream = fs.createReadStream(filePath, { highWaterMark: totalsize });
 		const sliceSize = 20;
 
@@ -62,8 +65,31 @@ describe("StreamUpload", () => {
 		assert.isDefined(slice);
 		assert.isDefined(retrySlice);
 		assert.equal(sliceSize, (slice as Buffer).length);
+	});
 
-		console.log(retrySlice);
-		console.log(slice);
+	it("New Range.Minimum greater than previous Range.Minimum and new Range.Maximum is equal previous Range.Maximum", async () => {
+		const readStream = fs.createReadStream(filePath, { highWaterMark: totalsize });
+		const sliceSize = 20;
+
+		const upload = new StreamUpload(readStream, fileName, totalsize);
+
+		const slice = await upload.sliceFile({ minValue: 0, maxValue: sliceSize - 1 });
+		const retrySlice = await upload.sliceFile({ minValue: 15, maxValue: sliceSize - 1 });
+		assert.isDefined(slice);
+		assert.isDefined(retrySlice);
+		assert.equal(sliceSize, (slice as Buffer).length);
+	});
+
+	it("New Range.Minimum greater than previous Range.Minimum and new Range.Maximum is greater than previous Range.Maximum", async () => {
+		const readStream = fs.createReadStream(filePath, { highWaterMark: totalsize });
+		const sliceSize = 20;
+
+		const upload = new StreamUpload(readStream, fileName, totalsize);
+
+		const slice = await upload.sliceFile({ minValue: 0, maxValue: sliceSize - 1 });
+		const retrySlice = await upload.sliceFile({ minValue: 15, maxValue: 21 });
+		assert.isDefined(slice);
+		assert.isDefined(retrySlice);
+		assert.equal(sliceSize, (slice as Buffer).length);
 	});
 });


### PR DESCRIPTION
fixes #452 

Problem - 
*`StreamUpload.sliceFile` function reads the first `n bytes` from the Stream.
* If an upload fails after the `0 - n` is read from the stream, then on upload resume the `sliceFile` function reads from `n+1` bytes and `0-n` is never uploaded.

Solution -
* Added `ChunkRecord` interface which keeps track of the previous slice and range.
* Compare the new upload range with the previous range and read the bytes accordingly. 

