### PR TITLE
Set Content-Type explicitly in LargeFileUploadTask.

### DIFF
--- a/src/tasks/LargeFileUploadTask.ts
+++ b/src/tasks/LargeFileUploadTask.ts
@@ -127,6 +127,7 @@ export class LargeFileUploadTask<T> {
 	 * @async
 	 * Makes request to the server to create an upload session
 	 * @param {Client} client - The GraphClient instance
+	 * @param {string} requestUrl - The URL to create the upload session
 	 * @param {any} payload - The payload that needs to be sent
 	 * @param {KeyValuePairObjectStringNumber} headers - The headers that needs to be sent
 	 * @returns The promise that resolves to LargeFileUploadSession
@@ -295,6 +296,7 @@ export class LargeFileUploadTask<T> {
 			.headers({
 				"Content-Length": `${range.maxValue - range.minValue + 1}`,
 				"Content-Range": `bytes ${range.minValue}-${range.maxValue}/${totalSize}`,
+				"Content-Type": "application/octet-stream",
 			})
 			.put(fileSlice);
 	}
@@ -314,6 +316,7 @@ export class LargeFileUploadTask<T> {
 			.headers({
 				"Content-Length": `${range.maxValue - range.minValue + 1}`,
 				"Content-Range": `bytes ${range.minValue}-${range.maxValue}/${totalSize}`,
+				"Content-Type": "application/octet-stream",
 			})
 			.responseType(ResponseType.RAW)
 			.put(fileSlice);

--- a/src/tasks/OneDriveLargeFileUploadTask.ts
+++ b/src/tasks/OneDriveLargeFileUploadTask.ts
@@ -22,6 +22,8 @@ import { getValidRangeSize } from "./OneDriveLargeFileUploadTaskUtil";
  * @property {string} fileName - Specifies the name of a file to be uploaded (with extension)
  * @property {string} [path] - The path to which the file needs to be uploaded
  * @property {number} [rangeSize] - Specifies the range chunk size
+ * @property {string} [conflictBehavior] - Conflict behaviour option
+ * @property {UploadEventHandlers} [uploadEventHandlers] - UploadEventHandlers attached to an upload task
  */
 export interface OneDriveLargeFileUploadOptions {
 	fileName: string;
@@ -35,8 +37,7 @@ export interface OneDriveLargeFileUploadOptions {
  * @interface
  * Signature to define options when creating an upload task
  * @property {string} fileName - Specifies the name of a file to be uploaded (with extension)
- * @property {string} [path] - The path to which the file needs to be uploaded
- * @property {number} [rangeSize] - Specifies the range chunk size
+ * @property {string} [conflictBehavior] - Conflict behaviour option
  */
 interface OneDriveFileUploadSessionPayLoad {
 	fileName: string;


### PR DESCRIPTION
## Summary

In `LargefileUploadTask`, set `Content-Type` to `application/octet-stream` explicitly, otherwise `application/json` will be used by default, which is not correct.

## Motivation

Although using the default `application/json` does not impact the functionality, if a client using the SDK has something like `http-interceptor` to examine the request payload, incorrect `Content-Type` can be misleading, for example, `application/json` suggests `plain/text` in `json` format.

## Test plan

N/A

## Types of changes

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

-   [x] I have read the **CONTRIBUTING** document.
-   [x] My code follows the code style of this project.
-   [ ] My change requires a change to the documentation.
-   [ ] I have updated the documentation accordingly.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
