### PR TITLE
Rename RedirectHandlerOptions variables to match purpose

### DIFF
--- a/src/middleware/options/RedirectHandlerOptions.ts
+++ b/src/middleware/options/RedirectHandlerOptions.ts
@@ -53,7 +53,7 @@ export class RedirectHandlerOptions implements MiddlewareOptions {
 	 * @private
 	 * A member holding default shouldRedirect callback
 	 */
-	private static defaultShouldRetry: ShouldRedirect = () => true;
+	private static defaultShouldRedirect: ShouldRedirect = () => true;
 
 	/**
 	 * @public
@@ -63,7 +63,7 @@ export class RedirectHandlerOptions implements MiddlewareOptions {
 	 * @param {ShouldRedirect} [shouldRedirect = RedirectHandlerOptions.DEFAULT_SHOULD_RETRY] - The should redirect callback
 	 * @returns An instance of RedirectHandlerOptions
 	 */
-	public constructor(maxRedirects: number = RedirectHandlerOptions.DEFAULT_MAX_REDIRECTS, shouldRedirect: ShouldRedirect = RedirectHandlerOptions.defaultShouldRetry) {
+	public constructor(maxRedirects: number = RedirectHandlerOptions.DEFAULT_MAX_REDIRECTS, shouldRedirect: ShouldRedirect = RedirectHandlerOptions.defaultShouldRedirect) {
 		if (maxRedirects > RedirectHandlerOptions.MAX_MAX_REDIRECTS) {
 			const error = new Error(`MaxRedirects should not be more than ${RedirectHandlerOptions.MAX_MAX_REDIRECTS}`);
 			error.name = "MaxLimitExceeded";

--- a/test/common/middleware/RedirectHandlerOptions.ts
+++ b/test/common/middleware/RedirectHandlerOptions.ts
@@ -46,7 +46,7 @@ describe("RedirectHandlerOptions.ts", () => {
 		it("Should initialize instance with default options", () => {
 			const options = new RedirectHandlerOptions();
 			assert.equal(options.maxRedirects, RedirectHandlerOptions["DEFAULT_MAX_REDIRECTS"]);
-			assert.equal(options.shouldRedirect, RedirectHandlerOptions["defaultShouldRetry"]);
+			assert.equal(options.shouldRedirect, RedirectHandlerOptions["defaultShouldRedirect"]);
 		});
 	});
 });


### PR DESCRIPTION
## Summary
Rename default ShouldRedirect callback function from `defaultShouldRetry` to `defaultShouldRedirect` in `RedirectHandlerOptions.ts` file.

## Motivation
For code to make sense.


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [x] Minor change. Renaming variable.

## Checklist

-   [x] I have read the **CONTRIBUTING** document.
-   [x] My code follows the code style of this project.
-   [ ] My change requires a change to the documentation.
-   [ ] I have updated the documentation accordingly.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
