### PR TITLE
Export BatchResponseBody interface type

### DIFF
--- a/src/browser/index.ts
+++ b/src/browser/index.ts
@@ -6,7 +6,7 @@
  */
 
 export { BatchRequestStep, BatchRequestData, BatchRequestContent, RequestData, BatchRequestBody } from "../content/BatchRequestContent";
-export { BatchResponseContent } from "../content/BatchResponseContent";
+export { BatchResponseBody, BatchResponseContent } from "../content/BatchResponseContent";
 
 export { AuthenticationHandler } from "../middleware/AuthenticationHandler";
 export { HTTPMessageHandler } from "../middleware/HTTPMessageHandler";

--- a/src/content/BatchResponseContent.ts
+++ b/src/content/BatchResponseContent.ts
@@ -23,7 +23,7 @@ interface KeyValuePairObject {
  * @property {KeyValuePairObject[]} responses - An array of key value pair representing response object for every request
  * @property {string} [@odata.nextLink] - The nextLink value to get next set of responses in case of asynchronous batch requests
  */
-interface BatchResponseBody {
+export interface BatchResponseBody {
 	responses: KeyValuePairObject[];
 	"@odata.nextLink"?: string;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@
  */
 
 export { BatchRequestBody, RequestData, BatchRequestContent, BatchRequestData, BatchRequestStep } from "./content/BatchRequestContent";
-export { BatchResponseContent } from "./content/BatchResponseContent";
+export { BatchResponseBody, BatchResponseContent } from "./content/BatchResponseContent";
 
 export { AuthenticationHandler } from "./middleware/AuthenticationHandler";
 export { HTTPMessageHandler } from "./middleware/HTTPMessageHandler";


### PR DESCRIPTION
The BatchResponseBody interface is needed as parameter to several public methods, in particular the constructor for BatchResponseContent, but is not exported. This makes it harder to write type-safe code that makes a batch request and passes the body from the response JSON to BatchResponseContent without relying on implicit "any" typing.

A similar PR may already be submitted! Please search among the [Pull request](https://github.com/microsoftgraph/msgraph-sdk-javascript/pulls) before creating one.

Thanks for submitting a pull request! Please provide enough information so that others can review your pull request.

**NOTE: PR's will be accepted only in case of appropriate information is provided below**

## Summary

Export an interface type which is used in other exported interfaces and methods.

## Motivation

The BatchResponseBody interface is needed as parameter to several public methods, in particular the constructor for BatchResponseContent, but is not exported. This makes it harder to write type-safe code that makes a batch request and passes the body from the response JSON to BatchResponseContent without relying on implicit "any" typing.

## Test plan

Trivial change affecting no code paths except exporting a previously internal type.

## Closing issues

## Types of changes

-   [X] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

-   [X] I have read the **CONTRIBUTING** document.
-   [X] My code follows the code style of this project.
-   [ ] My change requires a change to the documentation.
-   [ ] I have updated the documentation accordingly.
-   [ ] I have added tests to cover my changes.
-   [X] All new and existing tests passed.
