### PR TITLE
Support 'file description' in LargeFileUploadTask.

### DIFF
--- a/samples/typescript/tasks/OneDriveLargeFileUploadTask.ts
+++ b/samples/typescript/tasks/OneDriveLargeFileUploadTask.ts
@@ -22,6 +22,7 @@ import { client } from "../clientInitialization/ClientWithOptions";
 async function upload() {
 	const file = fs.createReadStream("./test.pdf");
 	const fileName = "FILENAME";
+	const fileDescription = "FILEDESCRIPTION";
 	const stats = fs.statSync(`./test.pdf`);
 	const totalSize = stats.size;
 
@@ -38,6 +39,7 @@ async function upload() {
 
 	const options: OneDriveLargeFileUploadOptions = {
 		fileName,
+		fileDescription,
 		conflictBehavior: "rename",
 		rangeSize: 1024 * 1024,
 		uploadEventHandlers,

--- a/src/tasks/OneDriveLargeFileUploadTask.ts
+++ b/src/tasks/OneDriveLargeFileUploadTask.ts
@@ -20,6 +20,7 @@ import { getValidRangeSize } from "./OneDriveLargeFileUploadTaskUtil";
  * @interface
  * Signature to define options when creating an upload task
  * @property {string} fileName - Specifies the name of a file to be uploaded (with extension)
+ * @property {string} [fileDescription] - Specifies the description of the file to be uploaded
  * @property {string} [path] - The path to which the file needs to be uploaded
  * @property {number} [rangeSize] - Specifies the range chunk size
  * @property {string} [conflictBehavior] - Conflict behaviour option
@@ -27,6 +28,7 @@ import { getValidRangeSize } from "./OneDriveLargeFileUploadTaskUtil";
  */
 export interface OneDriveLargeFileUploadOptions {
 	fileName: string;
+	fileDescription?: string;
 	path?: string;
 	rangeSize?: number;
 	conflictBehavior?: string;
@@ -37,10 +39,12 @@ export interface OneDriveLargeFileUploadOptions {
  * @interface
  * Signature to define options when creating an upload task
  * @property {string} fileName - Specifies the name of a file to be uploaded (with extension)
+ * @property {string} [fileDescription] - Specifies the description of the file to be uploaded
  * @property {string} [conflictBehavior] - Conflict behaviour option
  */
 interface OneDriveFileUploadSessionPayLoad {
 	fileName: string;
+	fileDescription?: string;
 	conflictBehavior?: string;
 }
 
@@ -160,6 +164,7 @@ export class OneDriveLargeFileUploadTask<T> extends LargeFileUploadTask<T> {
 		const requestUrl = OneDriveLargeFileUploadTask.constructCreateSessionUrl(options.fileName, options.path);
 		const uploadSessionPayload: OneDriveFileUploadSessionPayLoad = {
 			fileName: options.fileName,
+			fileDescription: options.fileDescription,
 			conflictBehavior: options.conflictBehavior,
 		};
 		const session = await OneDriveLargeFileUploadTask.createUploadSession(client, requestUrl, uploadSessionPayload);
@@ -185,6 +190,7 @@ export class OneDriveLargeFileUploadTask<T> extends LargeFileUploadTask<T> {
 			item: {
 				"@microsoft.graph.conflictBehavior": payloadOptions?.conflictBehavior || "rename",
 				name: payloadOptions?.fileName,
+				description: payloadOptions?.fileDescription,
 			},
 		};
 		return super.createUploadSession(client, requestUrl, payload);


### PR DESCRIPTION
## Summary

Support optional file description in LargeFileUploadTask

## Motivation

As a user, I want to have the option to add a file description when uploading a file via the LargeFileUploadTask API.

## Test plan

N/A.

## Closing issues

N/A.

## Types of changes

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

-   [x] I have read the **CONTRIBUTING** document.
-   [x] My code follows the code style of this project.
-   [ ] My change requires a change to the documentation.
-   [ ] I have updated the documentation accordingly.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
