### PR TITLE
Revert "Bump karma from 6.3.2 to 6.3.10"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1464,21 +1464,21 @@
 			"dev": true
 		},
 		"@types/component-emitter": {
-			"version": "1.2.11",
-			"resolved": "https://registry.npmjs.org/@types/component-emitter/-/component-emitter-1.2.11.tgz",
-			"integrity": "sha512-SRXjM+tfsSlA9VuG8hGO2nft2p8zjXCK1VcC6N4NXbBbYbSia9kzCChYQajIjzIqOOOuh5Ock6MmV2oux4jDZQ==",
+			"version": "1.2.10",
+			"resolved": "https://registry.npmjs.org/@types/component-emitter/-/component-emitter-1.2.10.tgz",
+			"integrity": "sha512-bsjleuRKWmGqajMerkzox19aGbscQX5rmmvvXl3wlIp5gMG1HgkiwPxsN5p070fBDKTNSPgojVbuY1+HWMbFhg==",
 			"dev": true
 		},
 		"@types/cookie": {
-			"version": "0.4.1",
-			"resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.4.1.tgz",
-			"integrity": "sha512-XW/Aa8APYr6jSVVA1y/DEIZX0/GMKLEVekNG727R8cs56ahETkRAy/3DR7+fJyh7oUgGwNQaRfXCun0+KbWY7Q==",
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.4.0.tgz",
+			"integrity": "sha512-y7mImlc/rNkvCRmg8gC3/lj87S7pTUIJ6QGjwHR9WQJcFs+ZMTOaoPrkdFA/YdbuqVEmEbb5RdhVxMkAcgOnpg==",
 			"dev": true
 		},
 		"@types/cors": {
-			"version": "2.8.12",
-			"resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.12.tgz",
-			"integrity": "sha512-vt+kDhq/M2ayberEtJcIN/hxXy1Pk+59g2FV/ZQceeaTyCtCucjL2Q7FXlFjtWn4n15KCr1NE2lNNFhp0lEThw==",
+			"version": "2.8.10",
+			"resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.10.tgz",
+			"integrity": "sha512-C7srjHiVG3Ey1nR6d511dtDkCEjxuN9W1HWAEjGq8kpcwmNM6JJkpC0xvabM7BXTG2wDq8Eu33iH9aQKa7IvLQ==",
 			"dev": true
 		},
 		"@types/eslint-visitor-keys": {
@@ -2231,9 +2231,9 @@
 			}
 		},
 		"base64-arraybuffer": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-1.0.1.tgz",
-			"integrity": "sha512-vFIUq7FdLtjZMhATwDul5RZWv2jpXQ09Pd6jcVEOvIsqCWTRFD/ONHNfyOS8dA/Ippi5dsIgpyKWKZaAKZltbA==",
+			"version": "0.1.4",
+			"resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.1.4.tgz",
+			"integrity": "sha1-mBjHngWbE1X5fgQooBfIOOkLqBI=",
 			"dev": true
 		},
 		"base64-js": {
@@ -2297,21 +2297,21 @@
 			"dev": true
 		},
 		"body-parser": {
-			"version": "1.19.1",
-			"resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.19.1.tgz",
-			"integrity": "sha512-8ljfQi5eBk8EJfECMrgqNGWPEY5jWP+1IzkzkGdFFEwFQZZyaZ21UqdaHktgiMlH0xLHqIFtE/u2OYE5dOtViA==",
+			"version": "1.19.0",
+			"resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.19.0.tgz",
+			"integrity": "sha512-dhEPs72UPbDnAQJ9ZKMNTP6ptJaionhP5cBb541nXPlW60Jepo9RV/a4fX4XWW9CuFNK22krhrj1+rgzifNCsw==",
 			"dev": true,
 			"requires": {
-				"bytes": "3.1.1",
+				"bytes": "3.1.0",
 				"content-type": "~1.0.4",
 				"debug": "2.6.9",
 				"depd": "~1.1.2",
-				"http-errors": "1.8.1",
+				"http-errors": "1.7.2",
 				"iconv-lite": "0.4.24",
 				"on-finished": "~2.3.0",
-				"qs": "6.9.6",
-				"raw-body": "2.4.2",
-				"type-is": "~1.6.18"
+				"qs": "6.7.0",
+				"raw-body": "2.4.0",
+				"type-is": "~1.6.17"
 			},
 			"dependencies": {
 				"debug": {
@@ -2330,9 +2330,9 @@
 					"dev": true
 				},
 				"qs": {
-					"version": "6.9.6",
-					"resolved": "https://registry.npmjs.org/qs/-/qs-6.9.6.tgz",
-					"integrity": "sha512-TIRk4aqYLNoJUbd+g2lEdz5kLWIuTMRagAXxl78Q0RiVjAOugHmeKNGdd3cwo/ktpf9aL9epCfFqWDEKysUlLQ==",
+					"version": "6.7.0",
+					"resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
+					"integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==",
 					"dev": true
 				}
 			}
@@ -2543,9 +2543,9 @@
 			"dev": true
 		},
 		"bytes": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.1.tgz",
-			"integrity": "sha512-dWe4nWO/ruEOY7HkUJ5gFt1DCFV9zPRoJr8pV0/ASQermOZjtq8jMjOprC0Kd10GLN+l7xaUPvxzJFWtxGu8Fg==",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.0.tgz",
+			"integrity": "sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg==",
 			"dev": true
 		},
 		"cache-base": {
@@ -2940,9 +2940,9 @@
 			"dev": true
 		},
 		"colors": {
-			"version": "1.4.2",
-			"resolved": "https://registry.npmjs.org/colors/-/colors-1.4.2.tgz",
-			"integrity": "sha512-5QhJWPFZqkKIieXJPpCprdOytvH7v0AGWpu9K2jZ4LWkGg3dVBNoYPgGGRpEsc0jb8Boy0ElYrdjH9uXfhRSqw==",
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
+			"integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
 			"dev": true
 		},
 		"combine-source-map": {
@@ -3648,30 +3648,27 @@
 			}
 		},
 		"engine.io": {
-			"version": "6.1.0",
-			"resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.1.0.tgz",
-			"integrity": "sha512-ErhZOVu2xweCjEfYcTdkCnEYUiZgkAcBBAhW4jbIvNG8SLU3orAqoJCiytZjYF7eTpVmmCrLDjLIEaPlUAs1uw==",
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/engine.io/-/engine.io-4.1.1.tgz",
+			"integrity": "sha512-t2E9wLlssQjGw0nluF6aYyfX8LwYU8Jj0xct+pAhfWfv/YrBn6TSNtEYsgxHIfaMqfrLx07czcMg9bMN6di+3w==",
 			"dev": true,
 			"requires": {
-				"@types/cookie": "^0.4.1",
-				"@types/cors": "^2.8.12",
-				"@types/node": ">=10.0.0",
 				"accepts": "~1.3.4",
 				"base64id": "2.0.0",
 				"cookie": "~0.4.1",
 				"cors": "~2.8.5",
 				"debug": "~4.3.1",
-				"engine.io-parser": "~5.0.0",
-				"ws": "~8.2.3"
+				"engine.io-parser": "~4.0.0",
+				"ws": "~7.4.2"
 			}
 		},
 		"engine.io-parser": {
-			"version": "5.0.2",
-			"resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.0.2.tgz",
-			"integrity": "sha512-wuiO7qO/OEkPJSFueuATIXtrxF7/6GTbAO9QLv7nnbjwZ5tYhLm9zxvLwxstRs0dcT0KUlWTjtIOs1T86jt12g==",
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-4.0.2.tgz",
+			"integrity": "sha512-sHfEQv6nmtJrq6TKuIz5kyEKH/qSdK56H/A+7DnAuUPWosnIZAS2NHNcPLmyjtY3cGS/MqJdZbUjW97JU72iYg==",
 			"dev": true,
 			"requires": {
-				"base64-arraybuffer": "~1.0.1"
+				"base64-arraybuffer": "0.1.4"
 			}
 		},
 		"enquirer": {
@@ -4562,9 +4559,9 @@
 			}
 		},
 		"follow-redirects": {
-			"version": "1.14.6",
-			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.6.tgz",
-			"integrity": "sha512-fhUl5EwSJbbl8AR+uYL2KQDxLkdSjZGR36xy46AO7cOMTrCMON6Sa28FmAnC2tRTDbd/Uuzz3aJBv7EBN7JH8A==",
+			"version": "1.13.3",
+			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.3.tgz",
+			"integrity": "sha512-DUgl6+HDzB0iEptNQEXLx/KhTmDb8tZUHSeLqpnjpknR70H0nC2t9N73BK6fN4hOvJ84pKlIQVQ4k5FFlBedKA==",
 			"dev": true
 		},
 		"for-in": {
@@ -5121,16 +5118,24 @@
 			"dev": true
 		},
 		"http-errors": {
-			"version": "1.8.1",
-			"resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.8.1.tgz",
-			"integrity": "sha512-Kpk9Sm7NmI+RHhnj6OIWDI1d6fIoFAtFt9RLaTMRlg/8w49juAStsrBgp0Dp4OdxdVbRIeKhtCUvoi/RuAhO4g==",
+			"version": "1.7.2",
+			"resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.2.tgz",
+			"integrity": "sha512-uUQBt3H/cSIVfch6i1EuPNy/YsRSOUBXTVfZ+yR7Zjez3qjBz6i9+i4zjNaoqcoFVI4lQJ5plg63TvGfRSDCRg==",
 			"dev": true,
 			"requires": {
 				"depd": "~1.1.2",
-				"inherits": "2.0.4",
-				"setprototypeof": "1.2.0",
+				"inherits": "2.0.3",
+				"setprototypeof": "1.1.1",
 				"statuses": ">= 1.5.0 < 2",
-				"toidentifier": "1.0.1"
+				"toidentifier": "1.0.0"
+			},
+			"dependencies": {
+				"inherits": {
+					"version": "2.0.3",
+					"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+					"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+					"dev": true
+				}
 			}
 		},
 		"http-proxy": {
@@ -6011,40 +6016,40 @@
 			}
 		},
 		"karma": {
-			"version": "6.3.10",
-			"resolved": "https://registry.npmjs.org/karma/-/karma-6.3.10.tgz",
-			"integrity": "sha512-Ofv+sgrkT8Czo6bzzQCvrwVyRSG8/3e7RbawEuxjfsINony+IR/S2csNRUFgPNfmWvju+dqi/MzQGOJ2LnlmfQ==",
+			"version": "6.3.2",
+			"resolved": "https://registry.npmjs.org/karma/-/karma-6.3.2.tgz",
+			"integrity": "sha512-fo4Wt0S99/8vylZMxNj4cBFyOBBnC1bewZ0QOlePij/2SZVWxqbyLeIddY13q6URa2EpLRW8ixvFRUMjkmo1bw==",
 			"dev": true,
 			"requires": {
 				"body-parser": "^1.19.0",
 				"braces": "^3.0.2",
-				"chokidar": "^3.5.1",
+				"chokidar": "^3.4.2",
 				"colors": "^1.4.0",
 				"connect": "^3.7.0",
 				"di": "^0.0.1",
 				"dom-serialize": "^2.2.1",
-				"glob": "^7.1.7",
-				"graceful-fs": "^4.2.6",
+				"glob": "^7.1.6",
+				"graceful-fs": "^4.2.4",
 				"http-proxy": "^1.18.1",
-				"isbinaryfile": "^4.0.8",
-				"lodash": "^4.17.21",
-				"log4js": "^6.3.0",
-				"mime": "^2.5.2",
+				"isbinaryfile": "^4.0.6",
+				"lodash": "^4.17.19",
+				"log4js": "^6.2.1",
+				"mime": "^2.4.5",
 				"minimatch": "^3.0.4",
 				"qjobs": "^1.2.0",
 				"range-parser": "^1.2.1",
 				"rimraf": "^3.0.2",
-				"socket.io": "^4.2.0",
+				"socket.io": "^3.1.0",
 				"source-map": "^0.6.1",
-				"tmp": "^0.2.1",
-				"ua-parser-js": "^0.7.30",
+				"tmp": "0.2.1",
+				"ua-parser-js": "^0.7.23",
 				"yargs": "^16.1.1"
 			},
 			"dependencies": {
 				"ansi-regex": {
-					"version": "5.0.1",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-					"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+					"integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
 					"dev": true
 				},
 				"ansi-styles": {
@@ -6082,19 +6087,19 @@
 					}
 				},
 				"chokidar": {
-					"version": "3.5.2",
-					"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.2.tgz",
-					"integrity": "sha512-ekGhOnNVPgT77r4K/U3GDhu+FQ2S8TnK/s2KbIGXi0SZWuwkZ2QNyfWdZW+TVfn84DpEP7rLeCt2UI6bJ8GwbQ==",
+					"version": "3.5.1",
+					"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.1.tgz",
+					"integrity": "sha512-9+s+Od+W0VJJzawDma/gvBNQqkTiqYTWLuZoyAsivsI4AaWTCzHG06/TMjsf1cYe9Cb97UCEhjz7HvnPk2p/tw==",
 					"dev": true,
 					"requires": {
-						"anymatch": "~3.1.2",
+						"anymatch": "~3.1.1",
 						"braces": "~3.0.2",
-						"fsevents": "~2.3.2",
-						"glob-parent": "~5.1.2",
+						"fsevents": "~2.3.1",
+						"glob-parent": "~5.1.0",
 						"is-binary-path": "~2.1.0",
 						"is-glob": "~4.0.1",
 						"normalize-path": "~3.0.0",
-						"readdirp": "~3.6.0"
+						"readdirp": "~3.5.0"
 					}
 				},
 				"cliui": {
@@ -6145,20 +6150,6 @@
 					"integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
 					"dev": true
 				},
-				"glob": {
-					"version": "7.2.0",
-					"resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
-					"integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
-					"dev": true,
-					"requires": {
-						"fs.realpath": "^1.0.0",
-						"inflight": "^1.0.4",
-						"inherits": "2",
-						"minimatch": "^3.0.4",
-						"once": "^1.3.0",
-						"path-is-absolute": "^1.0.0"
-					}
-				},
 				"is-binary-path": {
 					"version": "2.1.0",
 					"resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
@@ -6181,9 +6172,9 @@
 					"dev": true
 				},
 				"readdirp": {
-					"version": "3.6.0",
-					"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
-					"integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+					"version": "3.5.0",
+					"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.5.0.tgz",
+					"integrity": "sha512-cMhu7c/8rdhkHXWsY+osBhfSy0JikwpHK/5+imo+LpeasTF8ouErHrlYkwT0++njiyuDvc7OFY5T3ukvZ8qmFQ==",
 					"dev": true,
 					"requires": {
 						"picomatch": "^2.2.1"
@@ -6196,23 +6187,23 @@
 					"dev": true
 				},
 				"string-width": {
-					"version": "4.2.3",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-					"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+					"version": "4.2.2",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.2.tgz",
+					"integrity": "sha512-XBJbT3N4JhVumXE0eoLU9DCjcaF92KLNqTmFCnG1pf8duUxFGwtP6AD6nkjw9a3IdiRtL3E2w3JDiE/xi3vOeA==",
 					"dev": true,
 					"requires": {
 						"emoji-regex": "^8.0.0",
 						"is-fullwidth-code-point": "^3.0.0",
-						"strip-ansi": "^6.0.1"
+						"strip-ansi": "^6.0.0"
 					}
 				},
 				"strip-ansi": {
-					"version": "6.0.1",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-					"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+					"version": "6.0.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+					"integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
 					"dev": true,
 					"requires": {
-						"ansi-regex": "^5.0.1"
+						"ansi-regex": "^5.0.0"
 					}
 				},
 				"to-regex-range": {
@@ -6257,9 +6248,9 @@
 					}
 				},
 				"yargs-parser": {
-					"version": "20.2.9",
-					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
-					"integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
+					"version": "20.2.7",
+					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.7.tgz",
+					"integrity": "sha512-FiNkvbeHzB/syOjIUxFDCnhSfzAL8R5vs40MgLFBorXACCOAEaWu0gRZl14vG8MR9AOJIZbmkjhusqBYZ3HTHw==",
 					"dev": true
 				}
 			}
@@ -7182,9 +7173,9 @@
 			}
 		},
 		"mime": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
-			"integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
+			"version": "2.5.2",
+			"resolved": "https://registry.npmjs.org/mime/-/mime-2.5.2.tgz",
+			"integrity": "sha512-tqkh47FzKeCPD2PUiPB6pkbMzsCasjxAfC62/Wap5qrUWcb+sFasXUC5I3gYM5iBM8v/Qpn4UK0x+j0iHyFPDg==",
 			"dev": true
 		},
 		"mime-db": {
@@ -8684,13 +8675,13 @@
 			"dev": true
 		},
 		"raw-body": {
-			"version": "2.4.2",
-			"resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.4.2.tgz",
-			"integrity": "sha512-RPMAFUJP19WIet/99ngh6Iv8fzAbqum4Li7AD6DtGaW2RpMB/11xDoalPiJMTbu6I3hkbMVkATvZrqb9EEqeeQ==",
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.4.0.tgz",
+			"integrity": "sha512-4Oz8DUIwdvoa5qMJelxipzi/iJIi40O5cGV1wNYp5hvZP8ZN0T+jiNkL0QepXs+EsQ9XJ8ipEDoiH70ySUJP3Q==",
 			"dev": true,
 			"requires": {
-				"bytes": "3.1.1",
-				"http-errors": "1.8.1",
+				"bytes": "3.1.0",
+				"http-errors": "1.7.2",
 				"iconv-lite": "0.4.24",
 				"unpipe": "1.0.0"
 			}
@@ -9171,9 +9162,9 @@
 			"dev": true
 		},
 		"setprototypeof": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
-			"integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.1.tgz",
+			"integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw==",
 			"dev": true
 		},
 		"sha.js": {
@@ -9440,34 +9431,26 @@
 			}
 		},
 		"socket.io": {
-			"version": "4.4.1",
-			"resolved": "https://registry.npmjs.org/socket.io/-/socket.io-4.4.1.tgz",
-			"integrity": "sha512-s04vrBswdQBUmuWJuuNTmXUVJhP0cVky8bBDhdkf8y0Ptsu7fKU2LuLbts9g+pdmAdyMMn8F/9Mf1/wbtUN0fg==",
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/socket.io/-/socket.io-3.1.2.tgz",
+			"integrity": "sha512-JubKZnTQ4Z8G4IZWtaAZSiRP3I/inpy8c/Bsx2jrwGrTbKeVU5xd6qkKMHpChYeM3dWZSO0QACiGK+obhBNwYw==",
 			"dev": true,
 			"requires": {
+				"@types/cookie": "^0.4.0",
+				"@types/cors": "^2.8.8",
+				"@types/node": ">=10.0.0",
 				"accepts": "~1.3.4",
 				"base64id": "~2.0.0",
-				"debug": "~4.3.2",
-				"engine.io": "~6.1.0",
-				"socket.io-adapter": "~2.3.3",
-				"socket.io-parser": "~4.0.4"
-			},
-			"dependencies": {
-				"debug": {
-					"version": "4.3.3",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
-					"integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
-					"dev": true,
-					"requires": {
-						"ms": "2.1.2"
-					}
-				}
+				"debug": "~4.3.1",
+				"engine.io": "~4.1.0",
+				"socket.io-adapter": "~2.1.0",
+				"socket.io-parser": "~4.0.3"
 			}
 		},
 		"socket.io-adapter": {
-			"version": "2.3.3",
-			"resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.3.3.tgz",
-			"integrity": "sha512-Qd/iwn3VskrpNO60BeRyCyr8ZWw9CPZyitW4AQwmRZ8zCiyDiL+znRnWX6tDHXnWn1sJrM1+b6Mn6wEDJJ4aYQ==",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.1.0.tgz",
+			"integrity": "sha512-+vDov/aTsLjViYTwS9fPy5pEtTkrbEKsw2M+oVSoFGw6OD1IpvlV1VPhUzNbofCQ8oyMbdYJqDtGdmHQK6TdPg==",
 			"dev": true
 		},
 		"socket.io-parser": {
@@ -10095,9 +10078,9 @@
 			}
 		},
 		"toidentifier": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
-			"integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
+			"integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==",
 			"dev": true
 		},
 		"tough-cookie": {
@@ -10228,9 +10211,9 @@
 			"dev": true
 		},
 		"ua-parser-js": {
-			"version": "0.7.31",
-			"resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.31.tgz",
-			"integrity": "sha512-qLK/Xe9E2uzmYI3qLeOmI0tEOt+TBBQyUIAh4aAgU05FVYzeZrKUdkAZfBNVGRaHVgV0TDkdEngJSw/SyQchkQ==",
+			"version": "0.7.28",
+			"resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.28.tgz",
+			"integrity": "sha512-6Gurc1n//gjp9eQNXjD9O3M/sMwVtN5S8Lv9bvOYBfKfDNiIIhqiyi01vMBO45u4zkDE420w/e0se7Vs+sIg+g==",
 			"dev": true
 		},
 		"uglify-es": {
@@ -10702,9 +10685,9 @@
 			}
 		},
 		"ws": {
-			"version": "8.2.3",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-8.2.3.tgz",
-			"integrity": "sha512-wBuoj1BDpC6ZQ1B7DWQBYVLphPWkm8i9Y0/3YdHjHKHiohOJ1ws+3OccDWtH+PoC9DZD5WOTrJvNbWvjS6JWaA==",
+			"version": "7.4.6",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-7.4.6.tgz",
+			"integrity": "sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==",
 			"dev": true
 		},
 		"xml2js": {


### PR DESCRIPTION
Reverts microsoftgraph/msgraph-sdk-javascript#550

Karma 6.3.10 has a dependency on the color -1.4.2 which seems to be pulled off the npm registry.