### PR TITLE
Report last reported sync progress before returning result

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,5 @@ samples/lib/
 test/development/secrets.ts
 
 .nyc_output/*
+
+.idea/*

--- a/src/tasks/LargeFileUploadTask.ts
+++ b/src/tasks/LargeFileUploadTask.ts
@@ -263,8 +263,8 @@ export class LargeFileUploadTask<T> {
 			 * (rawResponse.status === 200 && responseBody.id) -> This additional condition is applicable only for OneDrive API.
 			 */
 			if (rawResponse.status === 201 || (rawResponse.status === 200 && responseBody.id)) {
-				const uploadResult = UploadResult.CreateUploadResult(responseBody, rawResponse.headers);
-				return uploadResult;
+				this.reportProgress(uploadEventHandlers, nextRange);
+				return UploadResult.CreateUploadResult(responseBody, rawResponse.headers);
 			}
 
 			/* Handling the API issue where the case of Outlook upload response property -'nextExpectedRanges'  is not uniform.
@@ -275,9 +275,13 @@ export class LargeFileUploadTask<T> {
 				nextExpectedRanges: responseBody.NextExpectedRanges || responseBody.nextExpectedRanges,
 			};
 			this.updateTaskStatus(res);
-			if (uploadEventHandlers && uploadEventHandlers.progress) {
-				uploadEventHandlers.progress(nextRange, uploadEventHandlers.extraCallbackParam);
-			}
+			this.reportProgress(uploadEventHandlers, nextRange);
+		}
+	}
+
+	private reportProgress(uploadEventHandlers: UploadEventHandlers, nextRange: Range) {
+		if (uploadEventHandlers && uploadEventHandlers.progress) {
+			uploadEventHandlers.progress(nextRange, uploadEventHandlers.extraCallbackParam);
 		}
 	}
 

--- a/test/common/tasks/LargeFileUploadTask.ts
+++ b/test/common/tasks/LargeFileUploadTask.ts
@@ -177,7 +177,7 @@ describe("LargeFileUploadTask.ts", () => {
 				assert.isDefined(result);
 				assert.instanceOf(result, UploadResult);
 				assert.equal(result["location"], location);
-				assert.isFalse(isProgressReportCalled);
+				assert.isTrue(isProgressReportCalled);
 			});
 
 			it("Test without progress callback", async () => {


### PR DESCRIPTION
A similar PR may already be submitted! Please search among the [Pull request](https://github.com/microsoftgraph/msgraph-sdk-javascript/pulls) before creating one.

Thanks for submitting a pull request! Please provide enough information so that others can review your pull request.

**NOTE: PR's will be accepted only in case of appropriate information is provided below**

## Summary

Reports progress to 100% for large file upload task


## Motivation

When using large file upload progress listener, the last progress is not reported and is instead the upload result is returned


<!-- Make sure tests pass on Travis CI. -->

## Closing issues

Resolves https://github.com/microsoftgraph/msgraph-sdk-javascript/issues/915

Fixes #

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

-   [x] I have read the **CONTRIBUTING** document.
-   [x] My code follows the code style of this project.
-   [x] My change requires a change to the documentation.
-   [x] I have updated the documentation accordingly.
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
