### PR TITLE
Use gender neutral pronouns

### DIFF
--- a/docs/CreatingClientInstance.md
+++ b/docs/CreatingClientInstance.md
@@ -70,7 +70,7 @@ const client = Client.initWithMiddleware(clientOptions);
 
 ## 2. Create With Options
 
-Pass an [authProvider function](../src/IAuthProvider.ts) in [Options](../src/IOptions.ts) while initializing the Client. In this case, user has to provide his own implementation for getting and refreshing accessToken. A callback will be passed into this authProvider function, accessToken or error needs to be passed in to that callback.
+Pass an [authProvider function](../src/IAuthProvider.ts) in [Options](../src/IOptions.ts) while initializing the Client. In this case, user has to provide their own implementation for getting and refreshing accessToken. A callback will be passed into this authProvider function, accessToken or error needs to be passed in to that callback.
 
 ```typescript
 // Some callback function

--- a/docs/CustomMiddlewareChain.md
+++ b/docs/CustomMiddlewareChain.md
@@ -68,7 +68,7 @@ Can use own middlewares and the ones shipped with the library [[Here](../src/mid
 
 Using AuthenticationHandler [one shipped with the library] and MyLoggingHandler, and MyHttpMessageHandler [custom ones] to create a middleware chain here.
 
-NOTE: Instead of ImplicitMSALAuthenticationProvider, one can provide his own Authentication Handler. For more about using custom authentication provider, refer [here](./CustomAuthenticationProvider.md).
+NOTE: Instead of ImplicitMSALAuthenticationProvider, one can provide their own Authentication Handler. For more about using custom authentication provider, refer [here](./CustomAuthenticationProvider.md).
 
 ```typescript
 import { ImplicitMSALAuthenticationProvider } from "@microsoft/microsoft-graph-client";


### PR DESCRIPTION
## Summary

Replaces two instances of gendered pronouns ("his") with gender neutral pronouns ("their").

## Motivation

This makes the documentation more inclusive by not assuming the reader or developer identifies with he/him pronouns.

## Test plan

No tests are needed as this is a documentation change.

## Closing issues

None.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

-   [x] I have read the **CONTRIBUTING** document.
-   [x] My code follows the code style of this project.
-   [ ] My change requires a change to the documentation.
-   [x] I have updated the documentation accordingly.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
