### PR TITLE
refactor: update getTokenOptions name and add missing import to docs

### DIFF
--- a/docs/TokenCredentialAuthenticationProvider.md
+++ b/docs/TokenCredentialAuthenticationProvider.md
@@ -16,6 +16,7 @@
 // Import the TokenCredential class that you wish to use. This example uses a Client SecretCredential
 
 import { ClientSecretCredential } from "@azure/identity";
+import { Client } from "@microsoft/microsoft-graph-client";
 import { TokenCredentialAuthenticationProvider, TokenCredentialAuthenticationProviderOptions } from "@microsoft/microsoft-graph-client/authProviders/azureTokenCredentials";
 
 // Create an instance of the TokenCredential class that is imported

--- a/src/authentication/azureTokenCredentials/ITokenCredentialAuthenticationProviderOptions.ts
+++ b/src/authentication/azureTokenCredentials/ITokenCredentialAuthenticationProviderOptions.ts
@@ -11,8 +11,8 @@ import { AuthenticationProviderOptions } from "../../IAuthenticationProviderOpti
 /**
  * @interface
  * A signature represents the Authentication provider options for Token Credentials
- * @property {getTokenoptions} [GetTokenOptions] - Defines options for TokenCredential.getToken.
+ * @property {getTokenOptions} [GetTokenOptions] - Defines options for TokenCredential.getToken.
  */
 export interface TokenCredentialAuthenticationProviderOptions extends AuthenticationProviderOptions {
-	getTokenoptions?: GetTokenOptions;
+	getTokenOptions?: GetTokenOptions;
 }

--- a/src/authentication/azureTokenCredentials/TokenCredentialAuthenticationProvider.ts
+++ b/src/authentication/azureTokenCredentials/TokenCredentialAuthenticationProvider.ts
@@ -70,7 +70,7 @@ export class TokenCredentialAuthenticationProvider implements AuthenticationProv
 			error.message = "Scopes cannot be empty, Please provide scopes";
 			throw error;
 		}
-		const response = await this.tokenCredential.getToken(scopes, this.authenticationProviderOptions.getTokenoptions);
+		const response = await this.tokenCredential.getToken(scopes, this.authenticationProviderOptions.getTokenOptions);
 		if (response) {
 			return response.token;
 		}

--- a/test/node/authentication/TokenCredentialAuthenticationProvider.ts
+++ b/test/node/authentication/TokenCredentialAuthenticationProvider.ts
@@ -23,7 +23,7 @@ describe("TokenCredentialAuthenticationProvider.ts", () => {
 		}
 
 		const authProviderOptions: TokenCredentialAuthenticationProviderOptions = {
-			getTokenoptions: null,
+			getTokenOptions: null,
 			scopes,
 		};
 		const accessToken: AccessToken = { token: "dummy_valid_token", expiresOnTimestamp: 1 };
@@ -43,7 +43,7 @@ describe("TokenCredentialAuthenticationProvider.ts", () => {
 				throw new Error("Method definition for getToken is not found");
 			}
 			const authProviderOptions: TokenCredentialAuthenticationProviderOptions = {
-				getTokenoptions: null,
+				getTokenOptions: null,
 				scopes,
 			};
 			const accessToken: AccessToken = undefined;


### PR DESCRIPTION
A similar PR may already be submitted! Please search among the [Pull request](https://github.com/microsoftgraph/msgraph-sdk-javascript/pulls) before creating one.

Thanks for submitting a pull request! Please provide enough information so that others can review your pull request.

**NOTE: PR's will be accepted only in case of appropriate information is provided below**

## Summary

<!-- Summary of the PR -->
- Change `getTokenoptions` to `getTokenOptions` - more accurate camel casing
- Updated locations where `TokenCredentialAuthenticationProviderOptions.getTokenOptions` was used/refeferenced
- Add missing import to javascript sdk example.

## Motivation
When going through the docs, I encountered a missing import for the typescript example. As well, the `getTokenOptions` was not in accurate camel casing.

## Test plan
N/A: No new tests added

## Closing issues

N/A

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)
-   [x] Makes changes to existing documentation

## Checklist

-   [x] I have read the **CONTRIBUTING** document.
-   [x] My code follows the code style of this project.
-   [ ] My change requires a change to the documentation.
-   [x] I have updated the documentation accordingly.
-   [ ] I have added tests to cover my changes.
-   [ ] All new and existing tests passed.
