### PR TITLE
fix(pageIterator): stop mutating PageCollection

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6281,6 +6281,7 @@
 			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
 			"integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
 			"dev": true,
+			"hasInstallScript": true,
 			"optional": true,
 			"os": [
 				"darwin"

--- a/src/tasks/PageIterator.ts
+++ b/src/tasks/PageIterator.ts
@@ -89,9 +89,16 @@ export class PageIterator {
 	private complete: boolean;
 
 	/**
+	 * @private
 	 * Information to be added to the request
 	 */
 	private requestOptions: GraphRequestOptions;
+
+	/**
+	 * @private
+	 * Member holding the current position on the collection
+	 */
+	private cursor: number
 
 	/**
 	 * @public
@@ -109,6 +116,7 @@ export class PageIterator {
 		this.nextLink = pageCollection["@odata.nextLink"];
 		this.deltaLink = pageCollection["@odata.deltaLink"];
 		this.callback = callback;
+		this.cursor = 0;
 		this.complete = false;
 		this.requestOptions = requestOptions;
 	}
@@ -123,9 +131,10 @@ export class PageIterator {
 			return false;
 		}
 		let advance = true;
-		while (advance && this.collection.length !== 0) {
-			const item = this.collection.shift();
+		while (advance && this.cursor < this.collection.length) {
+			const item = this.collection[this.cursor];
 			advance = this.callback(item);
+			this.cursor++;
 		}
 		return advance;
 	}
@@ -182,7 +191,7 @@ export class PageIterator {
 				advance = false;
 			}
 		}
-		if (this.nextLink === undefined && this.collection.length === 0) {
+		if (this.nextLink === undefined && this.cursor >= this.collection.length) {
 			this.complete = true;
 		}
 	}

--- a/test/common/tasks/PageIterator.ts
+++ b/test/common/tasks/PageIterator.ts
@@ -79,6 +79,13 @@ describe("PageIterator.ts", () => {
 			assert.isTrue(pageIterator.isComplete());
 		});
 
+		it("Should not mutate the collection", async () => {
+			const collection = getPageCollection();
+			const pageIterator = new PageIterator(client, collection, truthyCallback);
+			await pageIterator.iterate();
+			assert.deepEqual(collection, getPageCollection());
+		});
+
 		it("Should not iterate over an empty collection", async () => {
 			const pageIterator = new PageIterator(client, getEmptyPageCollection(), truthyCallback);
 			halfWayCallbackCounter = 1;


### PR DESCRIPTION
A similar PR may already be submitted! Please search among the [Pull request](https://github.com/microsoftgraph/msgraph-sdk-javascript/pulls) before creating one.

Thanks for submitting a pull request! Please provide enough information so that others can review your pull request.

**NOTE: PR's will be accepted only in case of appropriate information is provided below**

## Summary

PageIterator is mutating the pageCollection he receive in his constructor when it iterates.
The pageCollection.value array will be empty after the call of the iterate method.
The iterate method should not mutate pageCollection.value.

(cfr: https://github.com/microsoftgraph/msgraph-sdk-javascript/issues/959)

## Motivation

Mutation of given parameter is always a bad things and lead application to unexpected behaviour.

## Test plan

Demonstrate the code is solid. Example: The exact commands you ran and their output.

I haded an unit test is the PR.

## Closing issues

Fixes #959

## Types of changes

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

-   [x] I have read the **CONTRIBUTING** document.
-   [x] My code follows the code style of this project.
-   [x] My change requires a change to the documentation.
-   [x] I have updated the documentation accordingly.
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
