### PR TITLE
Remove node 12 test in build

### DIFF
--- a/.azure-pipelines/ci-build-production.yml
+++ b/.azure-pipelines/ci-build-production.yml
@@ -20,8 +20,6 @@ stages:
       vmImage: windows-latest
     strategy:
       matrix:
-        Node 12:
-          NODE_VERSION: '12.x'
         Node 14:
           NODE_VERSION: '14.x'
         Node 16:


### PR DESCRIPTION
Node 12 is failing the prod build. https://microsoftgraph.visualstudio.com/Graph%20Developer%20Experiences/_build/results?buildId=104090&view=logs&j=6ee93217-dd90-5523-3164-ee16656da314&t=ccedd99f-4017-5313-45ba-56d914a47e80

This failure has already been handled in the CI validation https://github.com/microsoftgraph/msgraph-sdk-javascript/blob/dev/.github/workflows/ci_validation.yml

Removing the node 12 testing in the prod build yaml as it already done in the CI validation. 