### PR TITLE
Strip away version from batch request url

### DIFF
--- a/src/content/BatchRequestContent.ts
+++ b/src/content/BatchRequestContent.ts
@@ -209,10 +209,10 @@ export class BatchRequestContent {
 			// Strip away version
 			const endOfVersionStrPos = path.indexOf("/");
 			if (endOfVersionStrPos !== -1) {
-				path = path.substring(0, endOfVersionStrPos);
+				path = path.substring(endOfVersionStrPos, path.length);
 			}
 
-			requestData.url = request.url;
+			requestData.url = path;
 		} else {
 			requestData.url = request.url;
 		}

--- a/src/content/BatchRequestContent.ts
+++ b/src/content/BatchRequestContent.ts
@@ -200,22 +200,7 @@ export class BatchRequestContent {
 		};
 
 		// Stripping off hostname, port and url scheme
-		const hasHttpRegex = new RegExp("^https?://");
-
-		if (hasHttpRegex.test(request.url)) {
-			// Strip away host segment
-			let path = request.url.split(/.*?\/\/.*?\//)[1];
-
-			// Strip away version
-			const endOfVersionStrPos = path.indexOf("/");
-			if (endOfVersionStrPos !== -1) {
-				path = path.substring(endOfVersionStrPos, path.length);
-			}
-
-			requestData.url = path;
-		} else {
-			requestData.url = request.url;
-		}
+		requestData.url = request.url.replace(/^(?:http)?s?:?(?:\/\/)?[^\/]+\/(?:v1.0|beta)?/i, ''); // replaces <scheme>?<?>?<//><hostname:port>+</>?<version>+ by an empty string
 
 		requestData.method = request.method;
 		const headers = {};

--- a/src/content/BatchRequestContent.ts
+++ b/src/content/BatchRequestContent.ts
@@ -198,9 +198,25 @@ export class BatchRequestContent {
 		const requestData: RequestData = {
 			url: "",
 		};
-		const hasHttpRegex = new RegExp("^https?://");
+
 		// Stripping off hostname, port and url scheme
-		requestData.url = hasHttpRegex.test(request.url) ? "/" + request.url.split(/.*?\/\/.*?\//)[1] : request.url;
+		const hasHttpRegex = new RegExp("^https?://");
+
+		if (hasHttpRegex.test(request.url)) {
+			// Strip away host segment
+			let path = request.url.split(/.*?\/\/.*?\//)[1];
+
+			// Strip away version
+			const endOfVersionStrPos = path.indexOf("/");
+			if (endOfVersionStrPos !== -1) {
+				path = path.substring(0, endOfVersionStrPos);
+			}
+
+			requestData.url = request.url;
+		} else {
+			requestData.url = request.url;
+		}
+
 		requestData.method = request.method;
 		const headers = {};
 		request.headers.forEach((value, key) => {

--- a/test/common/content/BatchRequestContent.ts
+++ b/test/common/content/BatchRequestContent.ts
@@ -213,6 +213,14 @@ describe("BatchRequestContent.ts", () => {
 			assert.isDefined(content.requests[0].body);
 			assert.equal(typeof content.requests[0].body, "object");
 		});
+
+		it("Should parse path with url", async () => {
+			const req = getCreateFolderRequestCopy();
+			req.request = new Request("https://graph.microsoft.com/v1.0" + req.request.url);
+			const batchReq = new BatchRequestContent([req]);
+			const content = await batchReq.getContent();
+			assert.equal(content.requests[0].url, "/me/drive/root/children");
+		});
 	});
 
 	describe("removeDependency", function() {


### PR DESCRIPTION
## Summary

<!-- Summary of the PR -->

## Motivation

In node 18, the `Request` object from the fetch API will throw an error if a full URL is not supplied. Using batch requests will not work unless supplying full Graph URLs including host name, like so: `https://graph.microsoft.com/v1.0/groups`. When using the SDK with batch requests this way, I discovered that the URL is not parsed correctly, as explained in #1178.

To be able to use this functionality right now, the developer is required to enter an incorrect path, excluding the versioning.

## Test plan

[I added a test](https://github.com/microsoftgraph/msgraph-sdk-javascript/pull/1179/commits/9b1c5630f6f3489f072e33996f7cfc69444032ba) ensuring that the URL is parsed correctly.

All tests pass running `npm run test`.

## Closing issues

Fixes #1178

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

-   [x] I have read the **CONTRIBUTING** document.
-   [x] My code follows the code style of this project.
-   [ ] My change requires a change to the documentation.
-   [ ] I have updated the documentation accordingly.
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
