### PR TITLE
Clearer middleware chain 

### DIFF
--- a/docs/CustomMiddlewareChain.md
+++ b/docs/CustomMiddlewareChain.md
@@ -18,7 +18,7 @@ import { Middleware } from "@microsoft/microsoft-graph-client";
 import { Context } from "@microsoft/microsoft-graph-client";
 
 export class MyLoggingHandler implements Middleware {
-	private nextMiddleware: Middleware;
+	private nextMiddleware?: Middleware;
 
 	public async execute(context: Context): Promise<void> {
 		try {
@@ -29,7 +29,7 @@ export class MyLoggingHandler implements Middleware {
 				url = context.request.url;
 			}
 			console.log(url);
-			return await this.nextMiddleware.execute(context);
+			return await this.nextMiddleware?.execute(context);
 		} catch (error) {
 			throw error;
 		}
@@ -117,7 +117,7 @@ import { Middleware } from "@microsoft/microsoft-graph-client";
 import { Context } from "@microsoft/microsoft-graph-client";
 
 export class MyLoggingHandler implements Middleware {
-	private nextMiddleware: Middleware;
+	private nextMiddleware?: Middleware;
 
 	public async execute(context: Context): Promise<void> {
 		try {
@@ -132,7 +132,7 @@ export class MyLoggingHandler implements Middleware {
 			} else {
 				console.log(url);
 			}
-			await this.nextMiddleware.execute(context);
+			await this.nextMiddleware?.execute(context);
 		} catch (error) {
 			throw error;
 		}

--- a/src/HTTPClientFactory.ts
+++ b/src/HTTPClientFactory.ts
@@ -11,23 +11,8 @@
 
 import { HTTPClient } from "./HTTPClient";
 import { AuthenticationProvider } from "./IAuthenticationProvider";
-import { AuthenticationHandler } from "./middleware/AuthenticationHandler";
-import { HTTPMessageHandler } from "./middleware/HTTPMessageHandler";
 import { Middleware } from "./middleware/IMiddleware";
-import { RedirectHandlerOptions } from "./middleware/options/RedirectHandlerOptions";
-import { RetryHandlerOptions } from "./middleware/options/RetryHandlerOptions";
-import { RedirectHandler } from "./middleware/RedirectHandler";
-import { RetryHandler } from "./middleware/RetryHandler";
-import { TelemetryHandler } from "./middleware/TelemetryHandler";
-
-/**
- * @private
- * To check whether the environment is node or not
- * @returns A boolean representing the environment is node or not
- */
-const isNodeEnvironment = (): boolean => {
-	return typeof process === "object" && typeof require === "function";
-};
+import { MiddlewareFactory } from "./middleware/MiddlewareFactory";
 
 /**
  * @class
@@ -48,21 +33,17 @@ export class HTTPClientFactory {
 	 * 		  them will remain same. For example, Retry and Redirect handlers might be working multiple times for a request based on the response but their auth token would remain same.
 	 */
 	public static createWithAuthenticationProvider(authProvider: AuthenticationProvider): HTTPClient {
-		const authenticationHandler = new AuthenticationHandler(authProvider);
-		const retryHandler = new RetryHandler(new RetryHandlerOptions());
-		const telemetryHandler = new TelemetryHandler();
-		const httpMessageHandler = new HTTPMessageHandler();
+		const middlewareChain = MiddlewareFactory.getDefaultMiddlewareChain(authProvider);
 
-		authenticationHandler.setNext(retryHandler);
-		if (isNodeEnvironment()) {
-			const redirectHandler = new RedirectHandler(new RedirectHandlerOptions());
-			retryHandler.setNext(redirectHandler);
-			redirectHandler.setNext(telemetryHandler);
-		} else {
-			retryHandler.setNext(telemetryHandler);
+		for (let i = 0; i < middlewareChain.length - 1; i++) {
+			const current = middlewareChain[i];
+			const next = middlewareChain[i + 1];
+			current.setNext?.(next);
 		}
-		telemetryHandler.setNext(httpMessageHandler);
-		return HTTPClientFactory.createWithMiddleware(authenticationHandler);
+
+		const chainHead = middlewareChain[0];
+
+		return HTTPClientFactory.createWithMiddleware(chainHead);
 	}
 
 	/**

--- a/src/middleware/AuthenticationHandler.ts
+++ b/src/middleware/AuthenticationHandler.ts
@@ -41,7 +41,7 @@ export class AuthenticationHandler implements Middleware {
 	 * @private
 	 * A member to hold next middleware in the middleware chain
 	 */
-	private nextMiddleware: Middleware;
+	private nextMiddleware?: Middleware;
 
 	/**
 	 * @public
@@ -85,6 +85,7 @@ export class AuthenticationHandler implements Middleware {
 				delete context.options.headers[AuthenticationHandler.AUTHORIZATION_HEADER];
 			}
 		}
+		if (!this.nextMiddleware) return;
 		return await this.nextMiddleware.execute(context);
 	}
 

--- a/src/middleware/ChaosHandler.ts
+++ b/src/middleware/ChaosHandler.ts
@@ -43,7 +43,7 @@ export class ChaosHandler implements Middleware {
 	 * @private
 	 * A member to hold next middleware in the middleware chain
 	 */
-	private nextMiddleware: Middleware;
+	private nextMiddleware?: Middleware;
 
 	/**
 	 * @public

--- a/src/middleware/HTTPMessageHandler.ts
+++ b/src/middleware/HTTPMessageHandler.ts
@@ -19,6 +19,12 @@ import { Middleware } from "./IMiddleware";
  */
 export class HTTPMessageHandler implements Middleware {
 	/**
+	 * @private
+	 * A member to hold next middleware in the middleware chain
+	 */
+	private nextMiddleware?: Middleware;
+
+	/**
 	 * @public
 	 * @async
 	 * To execute the current middleware
@@ -27,5 +33,17 @@ export class HTTPMessageHandler implements Middleware {
 	 */
 	public async execute(context: Context): Promise<void> {
 		context.response = await fetch(context.request, context.options);
+		if (!this.nextMiddleware) return;
+		return await this.nextMiddleware.execute(context);
+	}
+
+	/**
+	 * @public
+	 * To set the next middleware in the chain
+	 * @param {Middleware} next - The middleware instance
+	 * @returns Nothing
+	 */
+	public setNext(next: Middleware): void {
+		this.nextMiddleware = next;
 	}
 }

--- a/src/middleware/IMiddleware.ts
+++ b/src/middleware/IMiddleware.ts
@@ -14,5 +14,5 @@ import { Context } from "../IContext";
  */
 export interface Middleware {
 	execute: (context: Context) => Promise<void>;
-	setNext?: (middleware: Middleware) => void;
+	setNext: (middleware: Middleware) => void;
 }

--- a/src/middleware/RedirectHandler.ts
+++ b/src/middleware/RedirectHandler.ts
@@ -75,7 +75,7 @@ export class RedirectHandler implements Middleware {
 	 * @private
 	 * A member to hold next middleware in the middleware chain
 	 */
-	private nextMiddleware: Middleware;
+	private nextMiddleware?: Middleware;
 
 	/**
 	 * @public
@@ -190,7 +190,7 @@ export class RedirectHandler implements Middleware {
 	 * @returns A promise that resolves to nothing
 	 */
 	private async executeWithRedirect(context: Context, redirectCount: number, options: RedirectHandlerOptions): Promise<void> {
-		await this.nextMiddleware.execute(context);
+		await this.nextMiddleware?.execute(context);
 		const response = context.response;
 		if (redirectCount < options.maxRedirects && this.isRedirect(response) && this.hasLocationHeader(response) && options.shouldRedirect(response)) {
 			++redirectCount;

--- a/src/middleware/TelemetryHandler.ts
+++ b/src/middleware/TelemetryHandler.ts
@@ -54,7 +54,7 @@ export class TelemetryHandler implements Middleware {
 	 * @private
 	 * A member to hold next middleware in the middleware chain
 	 */
-	private nextMiddleware: Middleware;
+	private nextMiddleware?: Middleware;
 
 	/**
 	 * @public
@@ -88,6 +88,7 @@ export class TelemetryHandler implements Middleware {
 			delete context.options.headers[TelemetryHandler.CLIENT_REQUEST_ID_HEADER];
 			delete context.options.headers[TelemetryHandler.SDK_VERSION_HEADER];
 		}
+		if (!this.nextMiddleware) return;
 		return await this.nextMiddleware.execute(context);
 	}
 

--- a/test/DummyHTTPMessageHandler.ts
+++ b/test/DummyHTTPMessageHandler.ts
@@ -25,6 +25,12 @@ export class DummyHTTPMessageHandler implements Middleware {
 	private responses: Response[];
 
 	/**
+	 * @private
+	 * A member to hold next middleware in the middleware chain
+	 */
+	private nextMiddleware?: Middleware;
+
+	/**
 	 * @public
 	 * @constructor
 	 * To create an instance of DummyHTTPMessageHandler
@@ -54,6 +60,11 @@ export class DummyHTTPMessageHandler implements Middleware {
 	 */
 	public async execute(context: Context) {
 		context.response = this.responses.shift();
-		return;
+		if (!this.nextMiddleware) return;
+		return await this.nextMiddleware.execute(context);
+	}
+
+	public setNext(middleware: Middleware) {
+		this.nextMiddleware = middleware;
 	}
 }


### PR DESCRIPTION
Making it safer & more consistent to use the middleware chain with minor changes.

1. `Middleware.setNext()` is now required
    - No reason to not have it required. Before this change it is impossible to add middleware after the default `HTTPMessageHandler`.

2. `Middleware.#nextMiddleware` is made optional
    - Given that the users can use the default middleware served by this sdk we cannot be sure that nextMiddleware is always set.

3. `HTTPClientFactory.createWithAuthenticationProvider` uses the `MiddlewareFactory.getDefaultMiddlewareChain` internally
    - The logic of `MiddlewareFactory.getDefaultMiddlewareChain` was duplicated prior in `HTTPClientFactory.createWithAuthenticationProvider` which could result to accidental logic diversion.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature(ish) (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

-   [x] I have read the **CONTRIBUTING** document.
-   [x] My code follows the code style of this project.
-   [ ] My change requires a change to the documentation.
-   [x] I have updated the documentation accordingly.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
