### PR TITLE
Add option of adding extra headers to chunks' upload calls

### DIFF
--- a/src/tasks/LargeFileUploadTask.ts
+++ b/src/tasks/LargeFileUploadTask.ts
@@ -22,7 +22,7 @@ import { UploadResult } from "./FileUploadTask/UploadResult";
  * Signature to representing key value pairs
  * @property {[key: string] : string | number} - The Key value pair
  */
-interface KeyValuePairObjectStringNumber {
+export interface KeyValuePairObjectStringNumber {
 	[key: string]: string | number;
 }
 
@@ -42,10 +42,12 @@ interface UploadStatusResponse {
  * Signature to define options for upload task
  * @property {number} [rangeSize = LargeFileUploadTask.DEFAULT_FILE_SIZE] - Specifies the range chunk size
  * @property {UploadEventHandlers} uploadEventHandlers - UploadEventHandlers attached to an upload task
+ * @property {KeyValuePairObjectStringNumber} extraUploadHeaders - Extra headers added to upload calls for individual chunks 
  */
 export interface LargeFileUploadTaskOptions {
 	rangeSize?: number;
 	uploadEventHandlers?: UploadEventHandlers;
+	extraUploadHeaders?: KeyValuePairObjectStringNumber;
 }
 
 /**
@@ -298,6 +300,7 @@ export class LargeFileUploadTask<T> {
 		return await this.client
 			.api(this.uploadSession.url)
 			.headers({
+				...this.options.extraUploadHeaders,
 				"Content-Length": `${range.maxValue - range.minValue + 1}`,
 				"Content-Range": `bytes ${range.minValue}-${range.maxValue}/${totalSize}`,
 				"Content-Type": "application/octet-stream",
@@ -318,6 +321,7 @@ export class LargeFileUploadTask<T> {
 		return await this.client
 			.api(this.uploadSession.url)
 			.headers({
+				...this.options.extraUploadHeaders,
 				"Content-Length": `${range.maxValue - range.minValue + 1}`,
 				"Content-Range": `bytes ${range.minValue}-${range.maxValue}/${totalSize}`,
 				"Content-Type": "application/octet-stream",

--- a/src/tasks/OneDriveLargeFileUploadTask.ts
+++ b/src/tasks/OneDriveLargeFileUploadTask.ts
@@ -13,7 +13,7 @@ import { GraphClientError } from "../GraphClientError";
 import { Client } from "../index";
 import { FileUpload } from "./FileUploadTask/FileObjectClasses/FileUpload";
 import { UploadEventHandlers } from "./FileUploadTask/Interfaces/IUploadEventHandlers";
-import { FileObject, LargeFileUploadSession, LargeFileUploadTask, LargeFileUploadTaskOptions } from "./LargeFileUploadTask";
+import { FileObject, KeyValuePairObjectStringNumber, LargeFileUploadSession, LargeFileUploadTask, LargeFileUploadTaskOptions } from "./LargeFileUploadTask";
 import { getValidRangeSize } from "./OneDriveLargeFileUploadTaskUtil";
 
 /**
@@ -25,6 +25,7 @@ import { getValidRangeSize } from "./OneDriveLargeFileUploadTaskUtil";
  * @property {number} [rangeSize] - Specifies the range chunk size
  * @property {string} [conflictBehavior] - Conflict behaviour option
  * @property {UploadEventHandlers} [uploadEventHandlers] - UploadEventHandlers attached to an upload task
+ * @property {KeyValuePairObjectStringNumber} [extraUploadHeaders] - Extra headers added for upload of individual chunks
  */
 export interface OneDriveLargeFileUploadOptions {
 	fileName: string;
@@ -38,6 +39,7 @@ export interface OneDriveLargeFileUploadOptions {
     /// Set this property to override the default upload session url. Example: "/me/drive/special/{name}"
     /// </summary>
     uploadSessionURL?: string;
+	extraUploadHeaders?: KeyValuePairObjectStringNumber;
 }
 
 /**
@@ -177,6 +179,7 @@ export class OneDriveLargeFileUploadTask<T> extends LargeFileUploadTask<T> {
 		return new OneDriveLargeFileUploadTask(client, fileObject, session, {
 			rangeSize,
 			uploadEventHandlers: options.uploadEventHandlers,
+			extraUploadHeaders: options.extraUploadHeaders,
 		});
 	}
 


### PR DESCRIPTION
## Summary

Extending `LargeFileUploadTaskOptions` and `OneDriveLargeFileUploadOptions` with `extraUploadHeaders` with these headers being added to every `PUT` call during the upload session

## Motivation

We can send extra headers to the upload endpoint to specify some behaviour upon upload. We want to use this internally by our Msft team. My alias within Msft is `gcichosz`

## Test plan

The change is not covered by tests but these can be added if that is needed, please direct me to where and how tests for this would be added (currently I didn't find any tests checking the contents of single PUT call in the upload session)

## Types of changes

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

-   [x] I have read the **CONTRIBUTING** document.
-   [x] My code follows the code style of this project.
-   [ ] My change requires a change to the documentation.
-   [ ] I have updated the documentation accordingly.
-   [ ] I have added tests to cover my changes.
-   [ ] All new and existing tests passed.
