### PR TITLE
nextMiddleware may be undefined

### DIFF
--- a/docs/CustomMiddlewareChain.md
+++ b/docs/CustomMiddlewareChain.md
@@ -117,7 +117,7 @@ import { Middleware } from "@microsoft/microsoft-graph-client";
 import { Context } from "@microsoft/microsoft-graph-client";
 
 export class MyLoggingHandler implements Middleware {
-	private nextMiddleware: Middleware;
+	private nextMiddleware: Middleware | undefined;
 
 	public async execute(context: Context): Promise<void> {
 		try {
@@ -132,7 +132,9 @@ export class MyLoggingHandler implements Middleware {
 			} else {
 				console.log(url);
 			}
-			await this.nextMiddleware.execute(context);
+			if (this.nextMiddleware) {
+				await this.nextMiddleware.execute(context);
+			}
 		} catch (error) {
 			throw error;
 		}


### PR DESCRIPTION
## Summary

In the example, nextMiddleware may be undefined since setting it via setNext() is not mandatory. If it is the last middleware in the chain, setNext() must not be called therefore this.nextMiddleware.execute(context); cannot be executed

## Motivation

The code does not compile with TS since nextMiddleware is type actually Middleware | undefined.

## Test plan

- (Basic documentation change)

## Closing issues

<!-- Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->

Fixes #

## Types of changes

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

-   [x] I have read the **CONTRIBUTING** document.
-   [x] My code follows the code style of this project.
-   [ ] My change requires a change to the documentation.
-   [x] I have updated the documentation accordingly.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
