### PR TITLE
fix: prevent token leak via URL userinfo host confusion

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@microsoft/microsoft-graph-client",
-    "version": "3.0.7",
+    "version": "3.0.8",
     "description": "Microsoft Graph Client Library",
     "keywords": [
         "Microsoft",

--- a/src/GraphRequest.ts
+++ b/src/GraphRequest.ts
@@ -132,15 +132,25 @@ export class GraphRequest {
 	private parsePath = (path: string): void => {
 		// Strips out the base of the url if they passed in
 		if (path.indexOf("https://") !== -1) {
-			path = path.replace("https://", "");
+			// Use structured URL parsing to validate the URL and reject userinfo
+			let parsedUrl: URL;
+			try {
+				parsedUrl = new URL(path);
+			} catch {
+				throw new GraphClientError("Unable to parse the URL: " + path);
+			}
+			// Reject URLs with userinfo to prevent host-confusion attacks
+			if (parsedUrl.username !== "" || parsedUrl.password !== "") {
+				throw new GraphClientError("URL cannot contain user credentials: " + path);
+			}
 
-			// Find where the host ends
-			const endOfHostStrPos = path.indexOf("/");
+			// Extract host from the original string using the first "/" after "https://"
+			const withoutScheme = path.substring("https://".length);
+			const endOfHostStrPos = withoutScheme.indexOf("/");
 			if (endOfHostStrPos !== -1) {
-				// Parse out the host
-				this.urlComponents.host = "https://" + path.substring(0, endOfHostStrPos);
+				this.urlComponents.host = "https://" + withoutScheme.substring(0, endOfHostStrPos);
 				// Strip the host from path
-				path = path.substring(endOfHostStrPos + 1, path.length);
+				path = withoutScheme.substring(endOfHostStrPos + 1, withoutScheme.length);
 			}
 
 			// Remove the following version

--- a/src/GraphRequestUtil.ts
+++ b/src/GraphRequestUtil.ts
@@ -87,29 +87,20 @@ export const isCustomHost = (url: string, customHosts: Set<string>): boolean => 
  * @returns {boolean} - Returns true is for one of the provided endpoints.
  */
 const isValidEndpoint = (url: string, allowedHosts: Set<string> = GRAPH_URLS): boolean => {
-	// Valid Graph URL pattern - https://graph.microsoft.com/{version}/{resource}?{query-parameters}
-	// Valid Graph URL example - https://graph.microsoft.com/v1.0/
-	url = url.toLowerCase();
-
-	if (url.indexOf("https://") !== -1) {
-		url = url.replace("https://", "");
-
-		// Find where the host ends
-		const startofPortNoPos = url.indexOf(":");
-		const endOfHostStrPos = url.indexOf("/");
-		let hostName = "";
-		if (endOfHostStrPos !== -1) {
-			if (startofPortNoPos !== -1 && startofPortNoPos < endOfHostStrPos) {
-				hostName = url.substring(0, startofPortNoPos);
-				return allowedHosts.has(hostName);
-			}
-			// Parse out the host
-			hostName = url.substring(0, endOfHostStrPos);
-			return allowedHosts.has(hostName);
-		}
+	let parsedUrl: URL;
+	try {
+		parsedUrl = new URL(url);
+	} catch {
+		return false;
 	}
-
-	return false;
+	if (parsedUrl.protocol !== "https:") {
+		return false;
+	}
+	// Reject URLs with userinfo to prevent host-confusion attacks
+	if (parsedUrl.username !== "" || parsedUrl.password !== "") {
+		return false;
+	}
+	return allowedHosts.has(parsedUrl.hostname.toLowerCase());
 };
 
 /**

--- a/test/common/core/GraphRequestUtil.ts
+++ b/test/common/core/GraphRequestUtil.ts
@@ -7,7 +7,7 @@
 
 import { assert } from "chai";
 
-import { serializeContent, urlJoin } from "../../../src/GraphRequestUtil";
+import { serializeContent, urlJoin, isGraphURL, isCustomHost } from "../../../src/GraphRequestUtil";
 
 describe("GraphRequestUtil.ts", () => {
 	describe("urlJoin", () => {
@@ -75,6 +75,51 @@ describe("GraphRequestUtil.ts", () => {
 		it("Should return 'null' for the case of null content value", () => {
 			const val = null;
 			assert.equal(serializeContent(val), "null");
+		});
+	});
+
+	describe("isGraphURL - host confusion regression", () => {
+		it("Should accept valid Graph URLs", () => {
+			assert.isTrue(isGraphURL("https://graph.microsoft.com/v1.0/me"));
+			assert.isTrue(isGraphURL("https://graph.microsoft.com:443/v1.0/me"));
+			assert.isTrue(isGraphURL("https://graph.microsoft.us/v1.0/me"));
+			assert.isTrue(isGraphURL("https://dod-graph.microsoft.us/v1.0/me"));
+			assert.isTrue(isGraphURL("https://graph.microsoft.de/v1.0/me"));
+			assert.isTrue(isGraphURL("https://microsoftgraph.chinacloudapi.cn/v1.0/me"));
+			assert.isTrue(isGraphURL("https://canary.graph.microsoft.com/v1.0/me"));
+		});
+
+		it("Should reject URLs with userinfo (host confusion attack)", () => {
+			assert.isFalse(isGraphURL("https://graph.microsoft.com:443@attacker.example/v1.0/me"));
+			assert.isFalse(isGraphURL("https://graph.microsoft.com:8080@attacker.example/v1.0/me"));
+			assert.isFalse(isGraphURL("https://graph.microsoft.com@attacker.example/v1.0/me"));
+			assert.isFalse(isGraphURL("https://user:pass@graph.microsoft.com/v1.0/me"));
+		});
+
+		it("Should reject non-Graph hosts", () => {
+			assert.isFalse(isGraphURL("https://attacker.example/v1.0/me"));
+			assert.isFalse(isGraphURL("https://graph.microsoft.com.evil.example/v1.0/me"));
+		});
+
+		it("Should reject non-HTTPS URLs", () => {
+			assert.isFalse(isGraphURL("http://graph.microsoft.com/v1.0/me"));
+		});
+
+		it("Should reject malformed URLs", () => {
+			assert.isFalse(isGraphURL("not-a-url"));
+			assert.isFalse(isGraphURL(""));
+		});
+	});
+
+	describe("isCustomHost - host confusion regression", () => {
+		const customHosts = new Set<string>(["api.example.com"]);
+
+		it("Should accept valid custom host URLs", () => {
+			assert.isTrue(isCustomHost("https://api.example.com/v1.0/data", customHosts));
+		});
+
+		it("Should reject URLs with userinfo targeting custom hosts", () => {
+			assert.isFalse(isCustomHost("https://api.example.com:443@attacker.example/v1.0/data", customHosts));
 		});
 	});
 });

--- a/test/common/core/urlParsing.ts
+++ b/test/common/core/urlParsing.ts
@@ -61,4 +61,34 @@ describe("urlParsing.ts", () => {
 			}
 		}
 	});
+
+	describe("parsePath - userinfo rejection (security)", () => {
+		it("should throw for URLs with userinfo (host confusion attack)", () => {
+			assert.throws(() => {
+				client.api("https://graph.microsoft.com:443@attacker.example/v1.0/me");
+			}, /URL cannot contain user credentials/);
+		});
+
+		it("should throw for URLs with username only", () => {
+			assert.throws(() => {
+				client.api("https://graph.microsoft.com@attacker.example/v1.0/me");
+			}, /URL cannot contain user credentials/);
+		});
+
+		it("should throw for URLs with user:pass", () => {
+			assert.throws(() => {
+				client.api("https://user:pass@graph.microsoft.com/v1.0/me");
+			}, /URL cannot contain user credentials/);
+		});
+
+		it("should accept valid absolute URLs without userinfo", () => {
+			const request = client.api("https://graph.microsoft.com/v1.0/me");
+			assert.equal(request["buildFullUrl"](), "https://graph.microsoft.com/v1.0/me");
+		});
+
+		it("should accept valid absolute URLs with port", () => {
+			const request = client.api("https://graph.microsoft.com:443/v1.0/me");
+			assert.equal(request["buildFullUrl"](), "https://graph.microsoft.com:443/v1.0/me");
+		});
+	});
 });


### PR DESCRIPTION
## Summary

 Changes Made

  1. src/GraphRequestUtil.ts — isValidEndpoint (root cause fix)

  Replaced the hand-rolled indexOf(":") host extraction with new URL() parsing:

   - Rejects non-HTTPS URLs
   - Rejects any URL containing userinfo (username/password) — blocks the host-confusion attack
   - Uses parsedUrl.hostname (which correctly resolves the actual host, excluding userinfo and port)

  2. src/GraphRequest.ts — parsePath (defense-in-depth)

  Added new URL() validation at the entry point of path parsing:

   - Rejects malformed URLs with a clear error
   - Throws if userinfo is present — prevents credentialed URLs from ever entering the request pipeline
   - After validation, uses the original string for host/path extraction (preserving encoding and port for backward compatibility)


## Motivation

A vulnerability in the Microsoft Graph SDK for JavaScript allows an attacker to exploit a host-classification bug in the `isValidEndpoint` function, causing the SDK to misclassify attacker-controlled URLs as valid Microsoft Graph endpoints. This results in the SDK attaching and sending the caller's Microsoft Graph bearer token to the attacker's host. The issue is confirmed in version 3.0.7 and earlier, specifically when using the `node-fetch` runtime. The root cause is improper URL parsing that fails to correctly identify the real host when userinfo is included in the URL. The vulnerability can lead to the exposure of sensitive tokens, which can be replayed against Microsoft Graph services within the token's granted scopes.

## Test plan

Regression tests added

   - test/common/core/GraphRequestUtil.ts — tests for isGraphURL and isCustomHost covering all attack vectors
   - test/common/core/urlParsing.ts — tests that parsePath throws on userinfo URLs

