### PR TITLE
docs: fix responseType JSDoc and clarify auth samples

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ Here are some ways you can contribute to this documentation:
 -   To make small changes to an article, [Contribute using GitHub](#contribute-using-github).
 -   To make large changes, or changes that involve code, [Contribute using Git](#contribute-using-git).
 -   Report documentation bugs via GitHub Issues
--   Request new documentation at the [Office Developer Platform UserVoice](http://officespdev.uservoice.com) site.
+-   Request new documentation or report documentation issues via [GitHub Issues](https://github.com/microsoftgraph/msgraph-sdk-javascript/issues) in this repository.
 
 ## Contribute using GitHub
 

--- a/README.md
+++ b/README.md
@@ -120,6 +120,9 @@ The Microsoft Graph client is designed to make it simple to make calls to Micros
 
 For information on how to create a client instance, see [Creating Client Instance](./docs/CreatingClientInstance.md)
 
+> **Note:** Authentication provider samples in the README and docs are illustrative. They show how to wire an `AuthenticationProvider` into the client; they are not production-ready credential handling. For unit tests and mocking, see [`test/DummyAuthenticationProvider.ts`](./test/DummyAuthenticationProvider.ts) and the helpers under [`test/`](./test/).
+
+
 ### 3. Make requests to the graph
 
 Once you have authentication setup and an instance of Client, you can begin to make calls to the service. All requests should start with `client.api(path)` and end with an [action](./docs/Actions.md).

--- a/src/GraphRequest.ts
+++ b/src/GraphRequest.ts
@@ -502,7 +502,7 @@ export class GraphRequest {
 
 	/**
 	 * @public
-	 * Sets the api endpoint version for a request
+	 * Sets the response type for a request
 	 * @param {ResponseType} responseType - The response type value
 	 * @returns The same GraphRequest instance that is being called with
 	 */


### PR DESCRIPTION
## Summary
Fixes a copy-paste JSDoc error on `responseType` and clarifies that README auth samples are illustrative (with pointers to the local test mock provider). Also replaces a dead UserVoice docs-request link in CONTRIBUTING.

Fixes #1755 (JSDoc portion only).

## Changes
- `src/GraphRequest.ts`: correct `responseType` JSDoc
- `README.md`: note that auth samples are illustrative; link `test/DummyAuthenticationProvider.ts`
- `CONTRIBUTING.md`: route documentation requests to GitHub Issues instead of UserVoice

## Test plan
- [ ] Confirm JSDoc text matches method behavior
- [ ] Confirm README links resolve
- [ ] No live Graph / M365 login required

Docs/comments only.
